### PR TITLE
boxlist.rs: make id uniqueness local to EditorBuffer

### DIFF
--- a/src/frontend/boxlist.rs
+++ b/src/frontend/boxlist.rs
@@ -1,4 +1,3 @@
-use super::GLOB_ID_ALLOCATOR;
 use super::textbox::Textbox;
 use leptos::prelude::*;
 use std::collections::LinkedList;
@@ -6,37 +5,51 @@ use std::collections::LinkedList;
 /// Hold all the code lines in a linked list as a buffer.
 /// Each line is represented by a `CodeLineEntry`, it possesses the code text
 /// in a `RwSignal` to allow reactive updates.
-#[derive(Debug, Clone)]
-struct EditorBuffer(LinkedList<CodeLineEntry>);
+#[derive(Debug, Clone, Default)]
+struct EditorBuffer {
+    lines: LinkedList<CodeLineEntry>,
+    id_counter: usize,
+}
 
 impl EditorBuffer {
     #[allow(dead_code)]
     pub fn concat(&self) -> String {
-        self.0
+        self.lines
             .iter()
             .map(|entry| entry.value.get())
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    pub fn push_line(&mut self) {
+        self.id_counter += 1;
+        self.lines.push_back(CodeLineEntry::new(self.id_counter));
+    }
+
+    pub fn pop_line(&mut self) {
+        self.lines.pop_back();
     }
 }
 
 /// For now, it only holds a single line of code with a `RwSignal`
 /// `RwSignal` will cause reactive updates when it is modified.
 ///
-/// The id filed is the global unique id for object management handled by leptos
+/// The id is unique to the containing EditorBuffer and is maintained across
+/// insertions and deletions elsewhere in the buffer. This lets Leptos and
+/// the browser avoid re-rendering unchanged lines.
 #[derive(Debug, Clone)]
 struct CodeLineEntry {
-    id: usize,
     pub value: RwSignal<String>,
+    id: usize,
 }
 
 impl CodeLineEntry {
     /// ### Returns
     /// An instance holding an empty String.
-    pub fn new() -> CodeLineEntry {
+    pub fn new(id: usize) -> CodeLineEntry {
         CodeLineEntry {
-            id: GLOB_ID_ALLOCATOR.new_id(),
             value: RwSignal::new(String::new()),
+            id,
         }
     }
 }
@@ -45,16 +58,15 @@ impl CodeLineEntry {
 /// Initially, it will have 0 textboxes.
 #[component]
 pub fn Boxlist() -> impl IntoView {
-    let editor_buffer = EditorBuffer(LinkedList::new());
-    let (editor_buffer, set_editor_buffer) = signal(editor_buffer);
+    let (editor_buffer, set_editor_buffer) = signal(EditorBuffer::default());
 
     // Will be triggered by the button, see below
     let push_line = move |_| {
-        set_editor_buffer.write().0.push_back(CodeLineEntry::new());
+        set_editor_buffer.write().push_line();
     };
 
     let pop_line = move |_| {
-        set_editor_buffer.write().0.pop_back();
+        set_editor_buffer.write().pop_line();
     };
 
     view! {
@@ -62,7 +74,7 @@ pub fn Boxlist() -> impl IntoView {
             <button on:click=push_line>"Add Line"</button>
             <button on:click=pop_line>"Remove Line"</button>
             <ForEnumerate
-                each=move || editor_buffer.get().0
+                each=move || editor_buffer.get().lines
                 key=|entry| entry.id
                 children=move |index, entry| {
                     view! {
@@ -82,17 +94,29 @@ mod tests {
     use super::*;
     #[test]
     fn test_editor_buffer() {
-        let mut editor_buffer = EditorBuffer(LinkedList::new());
-        editor_buffer.0.push_back(CodeLineEntry::new());
-        editor_buffer.0.push_back(CodeLineEntry::new());
-        editor_buffer.0.push_back(CodeLineEntry::new());
-        editor_buffer.0.push_back(CodeLineEntry::new());
-        assert_eq!(editor_buffer.0.len(), 4);
-        editor_buffer.0.pop_back();
-        editor_buffer.0.pop_back();
-        assert_eq!(editor_buffer.0.len(), 2);
-        *editor_buffer.0.iter_mut().next().unwrap().value.write() = String::from("Hello");
-        *editor_buffer.0.iter_mut().nth(1).unwrap().value.write() = String::from("Leptos");
+        let mut editor_buffer = EditorBuffer::default();
+        editor_buffer.push_line();
+        editor_buffer.push_line();
+        editor_buffer.push_line();
+        editor_buffer.push_line();
+        assert_eq!(editor_buffer.lines.len(), 4);
+        editor_buffer.pop_line();
+        editor_buffer.pop_line();
+        assert_eq!(editor_buffer.lines.len(), 2);
+        editor_buffer
+            .lines
+            .iter_mut()
+            .next()
+            .unwrap()
+            .value
+            .set(String::from("Hello"));
+        editor_buffer
+            .lines
+            .iter_mut()
+            .nth(1)
+            .unwrap()
+            .value
+            .set(String::from("Leptos"));
         assert_eq!(editor_buffer.concat(), "Hello\nLeptos".to_string());
     }
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -4,21 +4,6 @@ use leptos::prelude::*;
 mod boxlist;
 mod textbox;
 
-/// This Global Id Allocator provides unique ids for objects.
-/// The id may be used by leptos to for handling objects dynamically.
-/// The exact number of id is not guaranteed
-static GLOB_ID_ALLOCATOR: GlobalIdAllocator =
-    GlobalIdAllocator(std::sync::atomic::AtomicUsize::new(0));
-
-#[derive(Debug)]
-struct GlobalIdAllocator(std::sync::atomic::AtomicUsize);
-
-impl GlobalIdAllocator {
-    pub fn new_id(&self) -> usize {
-        self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    }
-}
-
 #[component]
 pub fn App() -> impl IntoView {
     view! { <boxlist::Boxlist /> }


### PR DESCRIPTION
Patchup on your PR -- I think we can avoid creating a global atomic counter by letting the EditorBuffer handle the assignment of unique IDs to its lines. "ptal"!