### PR TITLE
Add fix_frames and match_frames fuction

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, anyhow};
+use std::ops::RangeInclusive;
 use wasm_tools::parse_binary_wasm;
 use wasmparser::{Parser, ValType};
 use wast::core::{Instruction, Module};
@@ -138,6 +139,90 @@ fn valtype_to_str(ty: ValType) -> &'static str {
     }
 }
 
+/// Represents a frame entry (like "block end" pair, etc.), with range recorded.
+/// The range is inclusive, containing both start instr number and end instr number.
+/// The start number begins at 0.
+pub type Frame = RangeInclusive<usize>;
+
+/// Fix frames by deactivated unmatched instrs and append **end** after the last instruction
+///
+/// ### Returns
+/// A tuple of a vector containing the deactivated indices, and the number of **end** appended at the end.
+pub fn fix_frames(instrs: &[Option<InstrInfo>]) -> (Vec<usize>, usize) {
+    let mut deactivated = Vec::new();
+    // Use stacks as memory of frame begining borders.
+    let mut frame_border_stack = Vec::new();
+
+    for (idx, instr) in instrs.iter().enumerate() {
+        let Some(instr) = instr else {
+            continue;
+        };
+        match instr {
+            InstrInfo::If | InstrInfo::OtherStructured => frame_border_stack.push((instr, idx)),
+            InstrInfo::Else => {
+                if let Some(prev) = frame_border_stack.last().cloned()
+                    && matches!(prev.0, InstrInfo::If)
+                {
+                    frame_border_stack.pop();
+                    frame_border_stack.push((instr, idx));
+                } else {
+                    deactivated.push(idx);
+                }
+            }
+            InstrInfo::End => {
+                if !frame_border_stack.is_empty() {
+                    frame_border_stack.pop();
+                } else {
+                    deactivated.push(idx);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    (deactivated, frame_border_stack.len())
+}
+
+/// Match frames for (Instruction or empty).
+///
+/// ### Panics
+/// When the input has unmatched frames
+pub fn match_frames(instrs: &[Option<InstrInfo>]) -> Vec<Frame> {
+    let mut frames = Vec::new();
+    // Use stacks as memory of frame begining borders.
+    let mut frame_border_stack = Vec::new();
+
+    for (idx, instr) in instrs.iter().enumerate() {
+        if let Some(instr) = instr {
+            match instr {
+                InstrInfo::If | InstrInfo::OtherStructured => {
+                    frame_border_stack.push((instr, idx));
+                }
+                InstrInfo::Else => {
+                    if let Some((prev, last_span_start)) = frame_border_stack.pop()
+                        && matches!(prev, InstrInfo::If)
+                    {
+                        let last_span_end = idx - 1;
+                        frames.push(last_span_start..=last_span_end);
+                    } else {
+                        panic!("Unmatched else");
+                    }
+                    frame_border_stack.push((instr, idx));
+                }
+                InstrInfo::End => {
+                    if let Some((_, last_span_start)) = frame_border_stack.pop() {
+                        frames.push(last_span_start..=idx);
+                    } else {
+                        panic!("Unmatched end");
+                    }
+                }
+                _ => (), // Ignore other instructions
+            }
+        }
+    }
+    frames
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,6 +284,86 @@ mod tests {
         assert!(!is_well_formed_func("block\ni32.const 1\nend\nend"));
         //unrecognized instructions
         assert!(!is_well_formed_func("i32.const 1\ni32.adx"));
+    }
+
+    #[test]
+    fn test_fix_frames() {
+        let instrs1 = ["block", "i32.const 42", "drop"];
+        let (deativated, appended) = fix_frames(
+            &instrs1
+                .into_iter()
+                .map(|instr| parse_instr(instr).unwrap())
+                .collect::<Vec<_>>(),
+        );
+        assert!(deativated.is_empty() && appended == 1);
+
+        let instrs2 = [
+            "if",    // 0
+            "block", // 1
+            "else",  // 2
+            "end",   // 3
+        ];
+
+        let (deativated, appended) = fix_frames(
+            &instrs2
+                .into_iter()
+                .map(|instr| parse_instr(instr).unwrap())
+                .collect::<Vec<_>>(),
+        );
+        assert!(deativated.len() == 1 && *deativated.first().unwrap() == 2 && appended == 1);
+    }
+
+    #[test]
+    fn test_frame_match() {
+        // Test case 1: Simple block
+        let instrs1 = ["block", "i32.const 42", "drop", "end"];
+        let frames1 = match_frames(
+            &instrs1
+                .into_iter()
+                .map(|instr| parse_instr(instr).unwrap())
+                .collect::<Vec<_>>(),
+        );
+        let expected1 = [0..=3]; // block from 0 to 3
+        assert_eq!(frames1, expected1);
+
+        // Test case 2: Complex nested structure
+        let instrs2 = [
+            "block",        // 0
+            "i32.const 42", // 1
+            "drop",         // 2
+            "end",          // 3
+            "block",        // 4
+            "loop",         // 5
+            "if",           // 6
+            "i32.const 43", // 7
+            "drop",         // 8
+            "else",         // 9
+            "i32.const 44", // 10
+            "drop",         // 11
+            "end",          // 12
+            "end",          // 13
+            "end",          // 14
+        ];
+
+        let mut frames2 = match_frames(
+            &instrs2
+                .into_iter()
+                .map(|instr| parse_instr(instr).unwrap())
+                .collect::<Vec<_>>(),
+        );
+        let mut expected2 = [
+            0..=3,  // first block
+            4..=14, // second block
+            6..=8,  // if part
+            5..=13, // loop
+            9..=12, // else part
+        ];
+
+        // Sort both vectors for comparison since order might vary
+        frames2.sort_by_key(|r| *r.start());
+        expected2.sort_by_key(|r| *r.start());
+
+        assert_eq!(frames2, expected2);
     }
     #[test]
     fn test_print_operands() -> Result<()> {


### PR DESCRIPTION
Closes #20 

### Summary
`fix_frames` takes `&[Option<InstrInfo>]` and works for all inputs.
`match_frames` takes `&[Option<InstrInfo>]` as the interface and only works for a well-matched function.

### Testing
1. `test_fix_frames` in `test` module
2. `test_frame_match` in `test` module