### PR TITLE
Wrap Wast Instruction struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +338,7 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.16",
  "leptos",
+ "ouroboros",
  "reactive_stores",
  "wasm-tools",
  "wasmparser",
@@ -1445,6 +1452,30 @@ name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ getrandom = { version = "0.2", features = ["js"] }
 web-sys = { version = "0.3.77", features = ["Selection", "Window", "Range"] }
 console_error_panic_hook = "0.1.7"
 reactive_stores = "0.2.2"
+ouroboros = "0.18.5"
 
 [package.metadata.leptos]
 assets-dir = "public"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,6 @@ use ouroboros::self_referencing;
 use wasm_tools::parse_binary_wasm;
 use wast::parser::{self, ParseBuffer};
 
-
 // Wrap wast instruction for future use.
 #[self_referencing]
 pub struct Instruction {


### PR DESCRIPTION
Refs #20 

### Summary
When trying to reuse `Instruction` struct in `wast` as our API, I encounter a problem because `Instruction` in `wast` requires a lifetime parameter, and it seems imposible to save this inside a leptos managed storage area.

So there are two ways to solve this problem.
1. Create our own `Instruction` struct and extract information we need from `Instruction` in `wast`.
2. Use a wrapper to eliminate the life parameter.

This PR is the implementation of the second method, and it uses `ouroboros` crate to circumvent self-referential restriction in rust.

Method 1 is implemented in [Wrap wast Instruction in an custom enum](https://github.com/codillon/codillon/pull/51).

### Note
`Store` in Leptos needs `Sync` which `ParseBuffer` does not implement. So we have the following options if we need to save the result of `parse_instr`:
1. wrap in some `Arc<Mutex<T>>` and store inside `Editline`
2. use some tricky syntax in Rust to assert we're single threaded
3. store ousite letpos' reactive primitives 