### PR TITLE
[DRAFT] Insert new lines (without selection / multi select)

### DIFF
--- a/public/codillon.css
+++ b/public/codillon.css
@@ -26,3 +26,7 @@ div.textentry:focus {
     outline: none;
     box-shadow: none;
 }
+
+/* div.line {
+    height: 2em;
+} */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,7 @@ impl Editor {
         // Update the position map.
         self.id_map.insert(self.next_id, line_no + 1);
 
-        // Add a new line directly below, using the cosmetic space to keep the line's
-        // dimensional integrity.
         let the_line = self.lines.lines().at_unkeyed(line_no);
-
         let new_text = if start_pos < the_line.read_untracked().text.len()
             && !the_line
                 .read_untracked()
@@ -77,6 +74,10 @@ impl Editor {
         {
             // Cut down the current line at the cursor start idx.
             let after_split = the_line.write().text.split_off(start_pos);
+            if the_line.read_untracked().text.is_empty() {
+                the_line.write_untracked().text = String::from(Self::COSMETIC_SPACE);
+            }
+
             after_split
         } else {
             String::from(Self::COSMETIC_SPACE)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,6 @@ impl Editor {
     const COSMETIC_SPACE: char = '\u{200B}';
 
     fn insert_line(&mut self, line_no: usize, start_pos: usize) {
-        // TODO: Disallow newline if the current line is the last line (and empty).
-
         // Re-map lines that will be affected by this change.
         // For each value greater than line no, add 1 to it.
         // I.e. if line_no is 1, we're creating a new line at idx 2
@@ -129,13 +127,6 @@ impl Editor {
                     let the_line = self.lines.lines().at_unkeyed(*line_no);
                     let (start_pos, end_pos) = the_line.write().preprocess_input(ev.clone());
 
-                    // if self.text.starts_with(Self::COSMETIC_SPACE) && self.text.len() > 3 {
-
-                    // if start_pos == the_line.read().text.len()
-                    //     || the_line.read().text.starts_with(Self::COSMETIC_SPACE)
-                    // {
-                    // This scares me because we're still in front of the cosmetic space
-                    //
                     leptos_dom::log!(
                         "Line info at insert line, {} {} {}",
                         start_pos,


### PR DESCRIPTION
This PR is still a WIP -- I'm just making it a draft PR to document some of my changes.

It appears there's a mis-sync between something in the DOM and the updates that occur when we add a line. To test this, I'd recommend doing the following:
1. Add a line break at cursor position (0,0) -> now there should be a newline before the 3 "Hello, world" statements
2. Make small edits (large edits cause panics once the edits are longer than the shown text content) to each of the statements and observe the following:
    a. Changes to the **first** statement appear only after writing to the **last** statement
    b. Changes to the other statements appear only after writing to the **statement before**

This seems to show that however we're doing rendering in the DOM is "off" by a line -- we can only get text for a "shifted" line to render by making changes to "where the line used to be".

I'll leave more findings as I discover them...