### PR TITLE
Add line well formedness enforcement

### DIFF
--- a/public/codillon.css
+++ b/public/codillon.css
@@ -26,3 +26,8 @@ div.textentry:focus {
     outline: none;
     box-shadow: none;
 }
+
+div.grey
+{
+    color: grey;
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -32,7 +32,7 @@ impl LogicSelection {
         LogicSelection { anchor, focus }
     }
 
-    pub fn is_collapsed(&self) -> bool {
+    pub fn is_cursor(&self) -> bool {
         self.anchor == self.focus
     }
 
@@ -278,7 +278,6 @@ impl Editor {
         match ev.key().as_str() {
             "ArrowUp" => {
                 if let Some(selection) = self.get_current_logic_selection()
-                    && selection.is_collapsed()
                     && let Some(malformed_line_id) = self.malformed_line_id()
                     && malformed_line_id
                         == *self.lines().read_untracked()[selection.focus.0]
@@ -290,9 +289,7 @@ impl Editor {
             }
 
             "ArrowDown" => {
-                if let Some(selection) = self.get_current_logic_selection()
-                    && selection.is_collapsed()
-                {
+                if let Some(selection) = self.get_current_logic_selection() {
                     if let Some(malformed_line_id) = self.malformed_line_id()
                         && malformed_line_id
                             == *self.lines().read_untracked()[selection.focus.0]
@@ -307,7 +304,7 @@ impl Editor {
             }
             "ArrowLeft" => {
                 if let Some(selection) = self.get_current_logic_selection()
-                    && selection.is_collapsed()
+                    && selection.is_cursor()
                 {
                     if selection.focus.1 == 0
                         && let Some(malformed_line_id) = self.malformed_line_id()
@@ -335,7 +332,7 @@ impl Editor {
             }
             "ArrowRight" => {
                 if let Some(selection) = self.get_current_logic_selection()
-                    && selection.is_collapsed()
+                    && selection.is_cursor()
                 {
                     let focus_line =
                         self.lines.read_untracked()[selection.focus.0].read_untracked();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -69,6 +69,19 @@ impl Editor {
         &mut self.set_selection
     }
 
+    pub fn malformed_line_id(&self) -> Option<usize>
+    {
+        for line in self.lines().read().iter()
+        {
+            if line.read().instr().is_err()
+            {
+                return Some(*line.read().id());
+            }
+        }
+        
+        None
+    }
+
     // The logic selection is defined as:
     // if self.set_selection is Some:
     //     self.set_selection

--- a/src/view.rs
+++ b/src/view.rs
@@ -7,7 +7,7 @@ pub type DomNode = Node;
 pub type DomRange = Range;
 pub type DomSelection = Selection;
 
-pub fn get_current_selection() -> DomSelection {
+pub fn get_current_domselection() -> DomSelection {
     web_sys::window()
         .expect("window not found")
         .get_selection()
@@ -39,9 +39,9 @@ pub fn Editor() -> impl IntoView {
     let (editor, set_editor) = signal(Editor::new());
 
     // If the selection or cursor changes, update it *after* updating the text.
-    let selection_signal = editor.read_untracked().selection();
+    let rerender_signal = RwSignal::new(());
     Effect::watch(
-        move || selection_signal.get(),
+        move || rerender_signal.get(),
         move |_, _, _| set_editor.write_untracked().update_selection(),
         false,
     );
@@ -64,9 +64,16 @@ pub fn Editor() -> impl IntoView {
                 <div
                     data-codillon-line-id=move || *child.read().id()
                     node_ref=child.read().div_ref()
+                    class=move || if child.read().instr().is_err() { "grey" } else { "" }
+                    // on:mousedown=move |ev| {
+                    //     if child.read().instr().is_ok() {
+                    //         ev.prevent_default();
+                    //         ev.stop_propagation();
+                    //     }
+                    // }
                 >
                     {move || {
-                        selection_signal.write();
+                        rerender_signal.write();
                         child.read().display_text().to_string()
                     }}
                 </div>

--- a/src/view.rs
+++ b/src/view.rs
@@ -65,12 +65,14 @@ pub fn Editor() -> impl IntoView {
                     data-codillon-line-id=move || *child.read().id()
                     node_ref=child.read().div_ref()
                     class=move || if child.read().instr().is_err() { "grey" } else { "" }
-                    // on:mousedown=move |ev| {
-                    //     if child.read().instr().is_ok() {
-                    //         ev.prevent_default();
-                    //         ev.stop_propagation();
-                    //     }
-                    // }
+                    on:mousedown=move |ev| {
+                        if let Some(malformed_line_id) = editor.read_untracked().malformed_line_id()
+                        && *child.read_untracked().id() != malformed_line_id
+                         {
+                            ev.prevent_default();
+                            ev.stop_propagation();
+                        }
+                    }
                 >
                     {move || {
                         rerender_signal.write();

--- a/src/view.rs
+++ b/src/view.rs
@@ -39,9 +39,9 @@ pub fn Editor() -> impl IntoView {
     let (editor, set_editor) = signal(Editor::new());
 
     // If the selection or cursor changes, update it *after* updating the text.
-    let rerender_signal = RwSignal::new(());
+    let selection_signal = *editor.read_untracked().set_selection();
     Effect::watch(
-        move || rerender_signal.get(),
+        move || selection_signal.get(),
         move |_, _, _| set_editor.write_untracked().update_selection(),
         false,
     );
@@ -52,11 +52,9 @@ pub fn Editor() -> impl IntoView {
             contenteditable
             spellcheck="false"
             on:beforeinput=move |ev| { set_editor.write().handle_input(ev) }
-            on:mousedown=move |_| { 
-                set_editor.write().set_selection_mut().take();
+            on:mousedown=move |_| {
                 set_editor.write().rationalize_selection() }
             on:keydown=move |ev| {
-                set_editor.write().set_selection_mut().take();
                 set_editor.write().handle_arrow(ev);
                 set_editor.write().rationalize_selection();
             }
@@ -78,7 +76,7 @@ pub fn Editor() -> impl IntoView {
                     }
                 >
                     {move || {
-                        rerender_signal.write();
+                        selection_signal.write();
                         child.read().display_text().to_string()
                     }}
                 </div>

--- a/src/view.rs
+++ b/src/view.rs
@@ -52,8 +52,11 @@ pub fn Editor() -> impl IntoView {
             contenteditable
             spellcheck="false"
             on:beforeinput=move |ev| { set_editor.write().handle_input(ev) }
-            on:mousedown=move |_| { set_editor.write().rationalize_selection() }
+            on:mousedown=move |_| { 
+                set_editor.write().set_selection_mut().take();
+                set_editor.write().rationalize_selection() }
             on:keydown=move |ev| {
+                set_editor.write().set_selection_mut().take();
                 set_editor.write().handle_arrow(ev);
                 set_editor.write().rationalize_selection();
             }


### PR DESCRIPTION
Issue: #4 

### Summary
1. Implement selection area enforcement by maintaining an `instr` field and maintaining `logic_selection` area.

### Effect
If frozen:
1. forbid arrow key from moving outside the enforcement area
2. forbid mouse click/press from moving outside and mark the malformed line by selection

https://github.com/user-attachments/assets/6c43af90-7051-4210-aa35-f56e039da33c


### Problem
When the user mouse down at the forbidden area, and then moves out of the window, then mouse up. We don't have an input event for this mouse up so the selection area is not updated. Willing to see ideas for this circumstance.

