### PR TITLE
UI & Leptos cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,6 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.16",
  "leptos",
- "reactive_stores",
  "wasm-tools",
  "wasmparser",
  "wasmprinter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ wast = "235.0.0"
 getrandom = { version = "0.2", features = ["js"] }
 web-sys = { version = "0.3.77", features = ["Selection", "Window", "Range"] }
 console_error_panic_hook = "0.1.7"
-reactive_stores = "0.2.2"
 wasmprinter = "0.235.0"
 wat = "1.235.0"
 anyhow = "1.0.98"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -20,6 +20,12 @@ pub enum SetSelection {
     MultiLine(usize, usize), // anchor line number, focus line number
 }
 
+impl Default for Editor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Editor {
     pub fn new() -> Self {
         Self {
@@ -360,7 +366,7 @@ impl Editor {
         // Verify that lines have unique IDs
         let mut ids = HashSet::new();
         for line in self.lines.get() {
-            if !ids.insert(line.read().id().clone()) {
+            if !ids.insert(*line.read().id()) {
                 return false;
             }
         }

--- a/src/line.rs
+++ b/src/line.rs
@@ -31,7 +31,7 @@ impl EditLine {
         const COSMETIC_SPACE: &str = "\u{FEFF}";
 
         if self.text.is_empty() {
-            &COSMETIC_SPACE
+            COSMETIC_SPACE
         } else {
             &self.text
         }
@@ -62,7 +62,7 @@ impl EditLine {
         self.text
             .char_indices()
             .nth(char_pos)
-            .expect(&format!("char pos {char_pos}"))
+            .unwrap_or_else(|| panic!("char pos {char_pos}"))
             .0
     }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,5 +1,4 @@
 use crate::editor::*;
-use crate::line::EditLineStoreFields;
 use leptos::{prelude::*, *};
 use web_sys::{Element, Node, Range, Selection, wasm_bindgen::JsCast};
 
@@ -37,8 +36,6 @@ pub fn find_id_from_node(orig_node: &Node) -> Option<usize> {
 // (each in their own div).
 #[component]
 pub fn Editor() -> impl IntoView {
-    const COSMETIC_SPACE: char = '\u{FEFF}';
-
     let (editor, set_editor) = signal(Editor::new());
 
     // If the selection or cursor changes, update it *after* updating the text.
@@ -63,18 +60,17 @@ pub fn Editor() -> impl IntoView {
             on:mouseup=move |_| { set_editor.write_untracked().rationalize_selection() }
             on:keyup=move |_| { set_editor.write_untracked().rationalize_selection() }
         >
-            <For each=move || editor.read().lines().lines() key=|line| *line.read().id() let(child)>
+            <For each=move || editor.read().lines().get() key=|line| *line.read().id() let(child)>
                 <div
                     data-codillon-line-id=move || *child.read().id()
-                    node_ref=child.read_untracked().div_ref()
+                    node_ref=child.read().div_ref()
                 >
                     {move || {
                         selection_signal.write();
-                        if child.logical_text().get().is_empty() {
-                            String::from(COSMETIC_SPACE)
-                        } else {
-                            child.logical_text().get()
-                        }
+                        leptos_dom::log!(
+                            "rendering {}: {}", child.read_untracked().id(), child.read_untracked().display_text().to_string()
+                        );
+                        child.read().display_text().to_string()
                     }}
                 </div>
             </For>

--- a/src/view.rs
+++ b/src/view.rs
@@ -51,14 +51,14 @@ pub fn Editor() -> impl IntoView {
             class="textentry"
             contenteditable
             spellcheck="false"
-            on:beforeinput=move |ev| { set_editor.write_untracked().handle_input(ev) }
-            on:mousedown=move |_| { set_editor.write_untracked().rationalize_selection() }
+            on:beforeinput=move |ev| { set_editor.write().handle_input(ev) }
+            on:mousedown=move |_| { set_editor.write().rationalize_selection() }
             on:keydown=move |ev| {
-                editor.read_untracked().maybe_cancel(ev);
-                set_editor.write_untracked().rationalize_selection();
+                set_editor.write().handle_arrow(ev);
+                set_editor.write().rationalize_selection();
             }
-            on:mouseup=move |_| { set_editor.write_untracked().rationalize_selection() }
-            on:keyup=move |_| { set_editor.write_untracked().rationalize_selection() }
+            on:mouseup=move |_| { set_editor.write().rationalize_selection() }
+            on:keyup=move |_| { set_editor.write().rationalize_selection() }
         >
             <For each=move || editor.read().lines().get() key=|line| *line.read().id() let(child)>
                 <div
@@ -67,9 +67,6 @@ pub fn Editor() -> impl IntoView {
                 >
                     {move || {
                         selection_signal.write();
-                        leptos_dom::log!(
-                            "rendering {}: {}", child.read_untracked().id(), child.read_untracked().display_text().to_string()
-                        );
                         child.read().display_text().to_string()
                     }}
                 </div>


### PR DESCRIPTION
This PR:

- Makes the Leptos structures more elementary (getting rid of `Store`, which seems to be causing more trouble than it's worth)
- Makes the handling of Unicode and the zero-width non-breaking space more correct (always splitting and setting the cursor position on a char boundary, and making sure a single arrow key takes the user past each "empty" line)

I fear the DOM cursor positions are really in units of UTF-16 code units (and not Unicode Scalar Values which is what Rust expects), but... I'm not sure our Unicode handling needs to be **that** correct until we start wanting to accommodate emoji (and other non-BMP Unicode characters) in source-code comments.