### PR TITLE
Right arrow can only advance us if we're on the penultimate line or less

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -164,7 +164,7 @@ impl Editor {
                     && let Some(focus) = selection.focus_node()
                     && let Some(id) = find_id_from_node(&focus)
                     && let idx = self.id_map.get(&id).expect("line from id")
-                    && *idx < self.lines.read().len()
+                    && *idx < self.lines.read().len() - 1
                     && self.lines.read()[*idx].read().logical_text().is_empty()
                 {
                     ev.prevent_default();


### PR DESCRIPTION
There's a panic on main right now if we try and hit the rightArrow on a new line at the end of the document


https://github.com/user-attachments/assets/4c3c129c-9cee-493b-a33a-248f5fa22416

The culprit is that when handling the rightArrow, we currently check 

```
*idx < self.lines.read().len() 
```
as a condition for whether to advance the cursor to the next line, but in the case of the video, idx is 3 (i.e. what is visibly line 4), but 3 is less than the number of lines, so we put the cursor onto `*idx + 1`, and chaos ensues.

I updated the check to make sure that we're not on the last line (i.e. `self.lines.read().len() - 1`)