### PR TITLE
Enable deletion of lines

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -225,7 +225,8 @@ impl Editor {
 
             // First check if there's an active selection that spans different lines.
             if start_line_no != end_line_no && !is_collapsed {
-                // Delete all lines associated with the selections and re-run the op.
+                // Delete all lines associated with the selections.
+                // TODO: Re-run the desired operation.
                 self.delete_selected_lines(*start_line_no, *end_line_no);
                 return;
             }
@@ -239,8 +240,8 @@ impl Editor {
                 }
                 "deleteContentBackward" => {
                     let line_no = self.id_map.get(&line_id).expect("can't find line");
-
                     let the_line = self.lines.read()[*line_no];
+
                     let pos = the_line.write().get_inline_range_end(&ev);
                     // Pos = 0 ignores the cosmetic space
                     if pos == 0 && *line_no > 0 {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -227,11 +227,7 @@ impl Editor {
             if start_line_no != end_line_no && !is_collapsed {
                 // Delete all lines associated with the selections and re-run the op.
                 self.delete_selected_lines(*start_line_no, *end_line_no);
-                if ev.input_type().as_str() == "deleteContentBackward"
-                    || ev.input_type().as_str() == "deleteContentForward"
-                {
-                    return;
-                }
+                return;
             }
 
             match ev.input_type().as_str() {

--- a/src/line.rs
+++ b/src/line.rs
@@ -109,8 +109,6 @@ impl EditLine {
             .clone()
             .unchecked_into::<DomRange>();
 
-        let selected_line_id = get_current_selection().get_range_at(0).unwrap();
-
         let text_node = self.text_node();
 
         if range.start_container().expect("container") != text_node

--- a/src/line.rs
+++ b/src/line.rs
@@ -74,8 +74,8 @@ impl EditLine {
             .0
     }
 
-    // These functions should only be used if you know
-    // that the input event straddles two ranges and you
+    // These functions should only be used when
+    // the input event straddles two ranges and you
     // know that one is correct for your case. See the
     // Editor's handle_input delete cases.
     pub fn get_inline_range_start(&mut self, ev: &InputEvent) -> usize {

--- a/src/line.rs
+++ b/src/line.rs
@@ -49,6 +49,14 @@ impl EditLine {
         self.div_ref
     }
 
+    pub fn clear_line(&mut self) {
+        self.text.clear();
+    }
+
+    pub fn append_text(&mut self, new_text: String) {
+        self.text += &new_text;
+    }
+
     // Splits the current line at POS, returning what is removed (RHS).
     pub fn split_self(&mut self, pos: usize) -> String {
         self.text.split_off(self.char_to_byte(pos))
@@ -101,9 +109,10 @@ impl EditLine {
             .clone()
             .unchecked_into::<DomRange>();
 
+        let selected_line_id = get_current_selection().get_range_at(0).unwrap();
+
         let text_node = self.text_node();
 
-        // TODO: Reevaluate why we might need this.
         if range.start_container().expect("container") != text_node
             || range.end_container().expect("container") != text_node
         {

--- a/src/line.rs
+++ b/src/line.rs
@@ -66,6 +66,32 @@ impl EditLine {
             .0
     }
 
+    // These functions should only be used if you know
+    // that the input event straddles two ranges and you
+    // know that one is correct for your case. See the
+    // Editor's handle_input delete cases.
+    pub fn get_inline_range_start(&mut self, ev: &InputEvent) -> usize {
+        let range = ev
+            .get_target_ranges()
+            .get(0)
+            .clone()
+            .unchecked_into::<DomRange>();
+
+        let start_char_pos = range.start_offset().expect("offset") as usize;
+        self.char_to_byte(start_char_pos)
+    }
+
+    pub fn get_inline_range_end(&mut self, ev: &InputEvent) -> usize {
+        let range = ev
+            .get_target_ranges()
+            .get(0)
+            .clone()
+            .unchecked_into::<DomRange>();
+
+        let end_char_pos = range.end_offset().expect("offset") as usize;
+        self.char_to_byte(end_char_pos)
+    }
+
     // Gets the indices of the current inline selection.
     // Panics if the selection spans multiple lines.
     pub fn get_inline_range(&mut self, ev: &InputEvent) -> (usize, usize) {

--- a/src/line.rs
+++ b/src/line.rs
@@ -66,8 +66,9 @@ impl EditLine {
             .0
     }
 
-    // Handle leading spaces and return the selection range.
-    pub fn preprocess_input(&mut self, ev: &InputEvent) -> (usize, usize) {
+    // Gets the indices of the current inline selection.
+    // Panics if the selection spans multiple lines.
+    pub fn get_inline_range(&mut self, ev: &InputEvent) -> (usize, usize) {
         let range = ev
             .get_target_ranges()
             .get(0)
@@ -76,6 +77,7 @@ impl EditLine {
 
         let text_node = self.text_node();
 
+        // TODO: Reevaluate why we might need this.
         if range.start_container().expect("container") != text_node
             || range.end_container().expect("container") != text_node
         {
@@ -97,7 +99,7 @@ impl EditLine {
 
     // Handle insert and delete events for this line.
     pub fn handle_input(&mut self, ev: &InputEvent) -> usize {
-        let (start_pos, end_pos) = self.preprocess_input(ev);
+        let (start_pos, end_pos) = self.get_inline_range(ev);
         let mut cursor_pos = start_pos;
 
         match ev.input_type().as_str() {


### PR DESCRIPTION
This PR enables 3 kinds of deletions:

* Deletion with multiple selected lines
* Forwards delete
* Backwards delete 

There was reasonably jankiness when implementing this due to how input event ranges work in our system. For example, f you're at the start of a line and execute a "deleteContentBackward", the event is technically captured as a multiline event, because the start_id refers to the _previous line_. What makes this worse is that due to the cosmetic space, even if it looks like you're at the start of a line, you might not be according to the DOM, so there's no hard-and-fast rule about what your start or end range will always be relative to your position.

For this reason, I got the current line from the selection instead of from the InputEvent for deletion-related logic, since the selection (when collapsed), always represented the current line (which was not true of the InputEvent)

Note: this PR omits functionality for multi-line deletion by pressing a non-deletion key. Currently, that behavior just deletes the selected lines without logging a keystroke. The reason for this is that we can't ride the previous event's data because it contains metadata about selected nodes that no longer exist. It's definitely possible, but nothing I tried was graceful.

https://github.com/user-attachments/assets/c6b7e8e1-c0a8-4e30-abb8-c966d440635f

Resolves #16 