### PR TITLE
Use associated type for WithElement

### DIFF
--- a/src/dom_struct.rs
+++ b/src/dom_struct.rs
@@ -3,7 +3,6 @@
 
 use crate::web_support::{
     AccessToken, AnyElement, ArrayHandle, Component, ElementHandle, NodeListHandle, WithElement,
-    WithNode,
 };
 use delegate::delegate;
 
@@ -90,13 +89,8 @@ impl<Child: Structure, Element: AnyElement> Component for DomStruct<Child, Eleme
 }
 
 // Accessors for the parent element (only usable by the web_support module).
-impl<Child: Structure, Element: AnyElement> WithNode for DomStruct<Child, Element> {
-    fn with_node(&self, f: impl FnMut(&web_sys::Node), g: AccessToken) {
-        self.elem.with_node(f, g);
-    }
-}
-
-impl<Child: Structure, Element: AnyElement> WithElement<Element> for DomStruct<Child, Element> {
+impl<Child: Structure, Element: AnyElement> WithElement for DomStruct<Child, Element> {
+    type Element = Element;
     fn with_element(&self, f: impl FnMut(&Element), g: AccessToken) {
         self.elem.with_element(f, g);
     }

--- a/src/dom_vec.rs
+++ b/src/dom_vec.rs
@@ -1,8 +1,6 @@
 // A Codillon DOM "vector": a variable-length collection of Components of the same type
 
-use crate::web_support::{
-    AccessToken, AnyElement, Component, ElementHandle, WithElement, WithNode,
-};
+use crate::web_support::{AccessToken, AnyElement, Component, ElementHandle, WithElement};
 use delegate::delegate;
 
 pub struct DomVec<Child: Component, Element: AnyElement> {
@@ -60,13 +58,8 @@ impl<Child: Component, Element: AnyElement> Component for DomVec<Child, Element>
 }
 
 // Accessors for the parent element (only usable by the web_support module).
-impl<Child: Component, Element: AnyElement> WithNode for DomVec<Child, Element> {
-    fn with_node(&self, f: impl FnMut(&web_sys::Node), g: AccessToken) {
-        self.elem.with_node(f, g);
-    }
-}
-
-impl<Child: Component, Element: AnyElement> WithElement<Element> for DomVec<Child, Element> {
+impl<Child: Component, Element: AnyElement> WithElement for DomVec<Child, Element> {
+    type Element = Element;
     fn with_element(&self, f: impl FnMut(&Element), g: AccessToken) {
         self.elem.with_element(f, g);
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -66,13 +66,8 @@ impl Editor {
     }
 }
 
-impl WithNode for Editor {
-    fn with_node(&self, f: impl FnMut(&web_sys::Node), g: AccessToken) {
-        self.0.borrow().with_node(f, g);
-    }
-}
-
-impl WithElement<HtmlDivElement> for Editor {
+impl WithElement for Editor {
+    type Element = HtmlDivElement;
     fn with_element(&self, f: impl FnMut(&HtmlDivElement), g: AccessToken) {
         self.0.borrow().component.with_element(f, g);
     }


### PR DESCRIPTION
Here are the reasons: 
1. A `WithElement` should be `WithNode` and they should act on the same node in common sense.
2. Fewer Generic Arguments.
3. It is a redundancy to have both generic in the `WithElement` Trait and a **Dom Struct**. Just one `WithElement` for **Dom Struct** with its Generic specified.