### PR TITLE
Cargo.toml: harmonize versions of wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -65,22 +65,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -185,9 +185,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.55"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+checksum = "67e4efcbb5da11a92e8a609233aa1e8a7d91e38de0be865f016d14700d45a7fd"
 dependencies = [
  "clap",
 ]
@@ -245,9 +245,9 @@ dependencies = [
  "str_indices",
  "wasm-bindgen",
  "wasm-tools",
- "wasmparser 0.236.0",
- "wasmprinter 0.235.0",
- "wast 235.0.0",
+ "wasmparser",
+ "wasmprinter",
+ "wast",
  "wat",
  "web-sys",
 ]
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "js-sys"
 version = "0.3.77"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -750,7 +750,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_derive",
- "wast 236.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-backend"
 version = "0.2.100"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "bumpalo",
  "log",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1377,7 +1377,7 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.100"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1389,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.100"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "unicode-ident",
 ]
@@ -1410,19 +1410,9 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder",
+ "wasmparser",
  "wat",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.235.0",
 ]
 
 [[package]]
@@ -1432,7 +1422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3108979166ab0d3c7262d2e16a2190ffe784b2a5beb963edef154b5e8e07680b"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.236.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1451,8 +1441,8 @@ dependencies = [
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1466,8 +1456,8 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1482,7 +1472,7 @@ dependencies = [
  "log",
  "rand",
  "wasm-mutate",
- "wasmparser 0.236.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1497,8 +1487,8 @@ dependencies = [
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.236.0",
- "wasmparser 0.236.0",
+ "wasm-encoder",
+ "wasmparser",
  "wat",
 ]
 
@@ -1532,30 +1522,19 @@ dependencies = [
  "tempfile",
  "termcolor",
  "wasm-compose",
- "wasm-encoder 0.236.0",
+ "wasm-encoder",
  "wasm-metadata",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.236.0",
- "wasmprinter 0.236.0",
- "wast 236.0.0",
+ "wasmparser",
+ "wasmprinter",
+ "wast",
  "wat",
  "wit-component",
  "wit-encoder",
  "wit-parser",
  "wit-smith",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
-dependencies = [
- "bitflags",
- "indexmap 2.10.0",
- "semver",
 ]
 
 [[package]]
@@ -1573,37 +1552,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.235.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa8e9076de6b9544e6dab4badada518cca0bf4966d35b131bbd057aed8fa0a"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.235.0",
-]
-
-[[package]]
-name = "wasmprinter"
 version = "0.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64dc32256b566259d30be300eb142f366343b98f42077216c7dd5e0cf4dc086"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.236.0",
-]
-
-[[package]]
-name = "wast"
-version = "235.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda4293f626c99021bb3a6fbe4fbbe90c0e31a5ace89b5f620af8925de72e13"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width",
- "wasm-encoder 0.235.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1617,7 +1572,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.236.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -1626,13 +1581,13 @@ version = "1.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc31704322400f461f7f31a5f9190d5488aaeafb63ae69ad2b5888d2704dcb08"
 dependencies = [
- "wast 236.0.0",
+ "wast",
 ]
 
 [[package]]
 name = "web-sys"
 version = "0.3.77"
-source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#a5fa9928a600ed1fd022e76172f076df058ca4e9"
+source = "git+https://github.com/codillon/wasm-bindgen?branch=add-onbeforeinput#729ef1713e0bb75ec0bcafb08c30202f867ff976"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1844,10 +1799,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.236.0",
+ "wasm-encoder",
  "wasm-metadata",
- "wasmparser 0.236.0",
- "wast 236.0.0",
+ "wasmparser",
+ "wast",
  "wat",
  "wit-parser",
 ]
@@ -1880,7 +1835,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.236.0",
+ "wasmparser",
  "wat",
 ]
 
@@ -1989,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "str_indices",
  "wasm-bindgen",
  "wasm-tools",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.0",
  "wasmprinter 0.235.0",
  "wast 235.0.0",
  "wat",
@@ -1554,10 +1554,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.4",
  "indexmap 2.10.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -1570,6 +1568,7 @@ dependencies = [
  "hashbrown 0.15.4",
  "indexmap 2.10.0",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-wasm-tools = "1.235.0"
-wast = "235.0.0"
+wasm-tools = "1.236.0"
+wasmparser = "0.236.0"
+wast = "236.0.0"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 console_error_panic_hook = "0.1.7"
-wasmprinter = "0.235.0"
-wat = "1.235.0"
+wasmprinter = "0.236.0"
+wat = "1.236.0"
 anyhow = "1.0.98"
 delegate = "0.13.4"
 js-sys = "0.3.77"
 str_indices = "0.4.4"
 wasm-bindgen = "0.2.100"
 web-sys = { version = "0.3.77", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent"] }
-wasmparser = "0.236.0"
 
 [patch.crates-io]
 web-sys = { git = "https://github.com/codillon/wasm-bindgen", branch = "add-onbeforeinput" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 wasm-tools = "1.235.0"
-wasmparser = "0.235.0"
 wast = "235.0.0"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 console_error_panic_hook = "0.1.7"
@@ -17,6 +16,7 @@ js-sys = "0.3.77"
 str_indices = "0.4.4"
 wasm-bindgen = "0.2.100"
 web-sys = { version = "0.3.77", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent"] }
+wasmparser = "0.236.0"
 
 [patch.crates-io]
 web-sys = { git = "https://github.com/codillon/wasm-bindgen", branch = "add-onbeforeinput" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod dom_struct;
 pub mod dom_text;
 pub mod dom_vec;
+pub mod utils;
 pub mod web_support;
 
 pub mod editor;


### PR DESCRIPTION
Two versions of wasmparser were included in recent PR#61 (one was a dependency of wasm_tools and the other was a dependency of the codillon crate). I removed wasmparser and added again to fix the issue.