### PR TITLE
Implement MultiLine Editing Features

### DIFF
--- a/src/dom_text.rs
+++ b/src/dom_text.rs
@@ -3,7 +3,7 @@
 // string, and enforces that the DOM contents will match the Rust contents.
 
 use crate::web_support::{AccessToken, Component, TextHandle, WithNode};
-use anyhow::{Result, bail};
+use anyhow::{Ok, Result, bail};
 
 #[derive(Default)]
 pub struct DomText {
@@ -55,12 +55,18 @@ impl DomText {
         Ok(utf16_idx + utf16_inserted)
     }
 
+    pub fn slice_utf16(&self, range: std::ops::Range<usize>) -> Result<&str> {
+        let start_byte_idx = self.safe_utf16_to_byte_idx(range.start)?;
+        let end_byte_idx = self.safe_utf16_to_byte_idx(range.end)?;
+        Ok(&self.contents[start_byte_idx..end_byte_idx])
+    }
+
     pub fn replace_range(
         &mut self,
         utf16_start_idx: usize,
         utf16_end_idx: usize,
         string: &str,
-    ) -> Result<usize> {
+    ) -> Result<()> {
         let byte_start_idx = self.safe_utf16_to_byte_idx(utf16_start_idx)?;
         let byte_end_idx = self.safe_utf16_to_byte_idx(utf16_end_idx)?;
         if utf16_start_idx > utf16_end_idx || byte_start_idx > byte_end_idx {
@@ -74,8 +80,7 @@ impl DomText {
             utf16_count.try_into()?,
             string,
         )?;
-        let utf16_inserted = str_indices::utf16::count(string);
-        Ok(utf16_start_idx + utf16_inserted)
+        Ok(())
     }
 
     pub fn len_utf16(&self) -> usize {

--- a/src/dom_vec.rs
+++ b/src/dom_vec.rs
@@ -23,6 +23,12 @@ impl<Child: Component, Element: AnyElement> DomVec<Child, Element> {
         self.elem.append_node(self.contents.last().unwrap());
     }
 
+    pub fn insert(&mut self, index: usize, elem: Child) {
+        self.contents.insert(index, elem);
+        self.elem
+            .insert_node(index, self.contents.get(index).unwrap());
+    }
+
     pub fn remove(&mut self, index: usize) -> Child {
         self.contents.remove(index)
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -227,7 +227,7 @@ impl Editor {
                 indentity_decorator,
             ),
             "deleteContentBackward" | "deleteContentForward" => {
-                fn delete_decorater(
+                fn delete_decorator(
                     editor: &Editor,
                     start_cursor: &mut (usize, usize),
                     end_cursor: &mut (usize, usize),
@@ -240,7 +240,7 @@ impl Editor {
                         end_cursor.1 = 0;
                     }
                 }
-                self.replace_range_with_decorator(target_range, "", delete_decorater)
+                self.replace_range_with_decorator(target_range, "", delete_decorator)
             }
             "insertParagraph" => {
                 self.replace_range_with_decorator(target_range, "\n", indentity_decorator)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ thread_local! {
 fn setup() -> Result<()> {
     DOCUMENT.with_borrow_mut(|doc| {
         let factory = doc.element_factory();
-        doc.set_body(Body::new((Editor::new(&factory), ()), factory.body()));
+        let body = factory.body();
+        doc.set_body(Body::new((Editor::new(factory), ()), body));
         doc.audit();
     });
 

--- a/src/web_support.rs
+++ b/src/web_support.rs
@@ -151,6 +151,20 @@ impl<T: AnyElement> ElementHandle<T> {
         )
     }
 
+    pub fn insert_node(&self, index: usize, child: &impl WithNode) {
+        child.with_node(
+            |node| {
+                let elem = self.elem.element();
+                let node_list = elem.child_nodes();
+                assert!(index <= node_list.length() as usize);
+                let anchor_node = node_list.item(index.try_into().expect("into u32"));
+                elem.insert_before(node, anchor_node.as_ref())
+                    .expect("insert_node");
+            },
+            TOKEN,
+        );
+    }
+
     pub fn attach_node(&self, child: &impl WithNode) {
         child.with_node(
             |node| self.elem.element().replace_children_with_node_1(node),


### PR DESCRIPTION
Closes #14 

### Summary
Here I implement more handlers for [beforeinput](https://developer.mozilla.org/en-US/docs/Web/API/Element/beforeinput_event) event:
- insertText
- insertFromPaste
- deleteContentBackward
- deleteContentForward
- insertParagraph(new added!)

All handlers with multiline enabled.

The implementations of these handlers are designed in a unified way.

### Note
Simple manual test on Windows Chrome passed. Not 100% sure this will work on all env. Maybe more tests should do on Linux, Firefox and Safari.