### PR TITLE
Add Line Color + Fix Mismatch Frame Error

### DIFF
--- a/public/codillon.css
+++ b/public/codillon.css
@@ -28,4 +28,8 @@ div.textentry:focus {
 }
 
 .grey-text { color: grey; }
+.inactive-text { 
+    color: grey;
+    text-decoration: line-through; 
+}
 .black-text { color: black; }

--- a/public/codillon.css
+++ b/public/codillon.css
@@ -26,3 +26,6 @@ div.textentry:focus {
     outline: none;
     box-shadow: none;
 }
+
+.grey-text { color: grey; }
+.black-text { color: black; }

--- a/src/dom_struct.rs
+++ b/src/dom_struct.rs
@@ -74,7 +74,8 @@ impl<Child: Structure, Element: AnyElement> DomStruct<Child, Element> {
     delegate! {
     to self.elem {
     pub fn set_attribute(&mut self, name: &str, value: &str);
-        pub fn set_onbeforeinput<F: Fn(InputEventHandle) + 'static>(&mut self, handler: F);
+    pub fn get_attribute(&self, name: &str) -> Option<&String>;
+    pub fn set_onbeforeinput<F: Fn(InputEventHandle) + 'static>(&mut self, handler: F);
     }
     }
 }

--- a/src/dom_vec.rs
+++ b/src/dom_vec.rs
@@ -38,6 +38,7 @@ impl<Child: Component, Element: AnyElement> DomVec<Child, Element> {
         pub fn is_empty(&self) -> bool;
         pub fn get(&self, index: usize) -> Option<&Child>;
         pub fn get_mut(&mut self, index: usize) -> Option<&mut Child>;
+        pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Child>;
     pub fn binary_search_by<'a, F>(&'a self, f: F) -> Result<usize, usize>
     where
             F: FnMut(&'a Child) -> std::cmp::Ordering;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -283,18 +283,18 @@ impl Editor {
         //grey out empty, malformed, and inactive instructions
         {
             let mut editor = self.0.borrow_mut();
-            for car in editor.component.iter_mut() {
-                let class = match car.borrow_sidecar().info {
+            for line in editor.component.iter_mut() {
+                let class = match line.borrow_sidecar().info {
                     InstrInfo::EmptyOrMalformed => "grey-text",
                     _ => {
-                        if !car.borrow_sidecar().active {
+                        if !line.borrow_sidecar().active {
                             "grey-text"
                         } else {
                             "black-text"
                         }
                     }
                 };
-                car.borrow_component_mut().set_attribute("class", class);
+                line.borrow_component_mut().set_attribute("class", class);
             }
         }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -6,7 +6,7 @@ use crate::{
     dom_text::DomText,
     dom_vec::DomVec,
     utils::{
-        FmtError, InstrInfo, LineInfos, LineInfosMut, OkModule, collect_operands, fix_frames,
+        FmtError, InstrKind, LineInfos, LineInfosMut, OkModule, collect_operands, fix_frames,
         parse_instr, str_to_binary,
     },
     web_support::{
@@ -29,17 +29,17 @@ type ComponentType = DomVec<LineWithInfo, HtmlDivElement>;
 
 #[derive(Copy, Clone)]
 pub struct LineInfo {
-    pub info: InstrInfo,
+    pub kind: InstrKind,
     pub active: bool,
 }
 
 impl LineInfo {
-    pub fn new(info: InstrInfo, active: bool) -> Self {
-        Self { info, active }
+    pub fn new(kind: InstrKind, active: bool) -> Self {
+        Self { kind, active }
     }
 
     pub fn is_instr(&self) -> bool {
-        self.info != InstrInfo::EmptyOrMalformed && self.active
+        self.kind != InstrKind::EmptyOrMalformed && self.active
     }
 }
 
@@ -92,13 +92,13 @@ impl Editor {
                     factory.span(),
                 ),
                 LineInfo {
-                    info: parse_instr(string),
+                    kind: parse_instr(string),
                     active: true,
                 },
             ));
             let line = component.get_mut(component.len() - 1).expect("DomSidecar");
-            let class = match line.borrow_sidecar().info {
-                InstrInfo::EmptyOrMalformed => "grey-text",
+            let class = match line.borrow_sidecar().kind {
+                InstrKind::EmptyOrMalformed => "grey-text",
                 _ => "black-text",
             };
             line.borrow_component_mut().set_attribute("class", class);
@@ -135,7 +135,7 @@ impl Editor {
         )?;
 
         let new_info = LineInfo {
-            info: parse_instr(self.line_text(start_line_index).get_contents()),
+            kind: parse_instr(self.line_text(start_line_index).get_contents()),
             active: true,
         };
 
@@ -148,8 +148,8 @@ impl Editor {
 
             *line.borrow_sidecar_mut() = new_info;
 
-            let class = match line.borrow_sidecar().info {
-                InstrInfo::EmptyOrMalformed => "grey-text",
+            let class = match line.borrow_sidecar().kind {
+                InstrKind::EmptyOrMalformed => "grey-text",
                 _ => "black-text",
             };
             line.borrow_component_mut().set_attribute("class", class);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -285,9 +285,7 @@ impl Editor {
             let mut editor = self.0.borrow_mut();
             for line in editor.component.iter_mut() {
                 let class = match line.borrow_sidecar().info {
-                    InstrInfo::EmptyOrMalformed => {
-                        "grey-text"
-                    },
+                    InstrInfo::EmptyOrMalformed => "grey-text",
                     _ => {
                         if !line.borrow_sidecar().active {
                             "inactive-text"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -23,8 +23,8 @@ use web_sys::{HtmlBrElement, HtmlDivElement, HtmlSpanElement, Text, console::log
 
 type DomBr = DomStruct<(), HtmlBrElement>;
 type LineContents = (DomText, (DomBr, ()));
-type Line = DomStruct<LineContents, HtmlSpanElement>;
-type LineWithInfo = DomSidecar<Line, LineInfo>;
+type LineSpan = DomStruct<LineContents, HtmlSpanElement>;
+type LineWithInfo = DomSidecar<LineSpan, LineInfo>;
 type ComponentType = DomVec<LineWithInfo, HtmlDivElement>;
 
 #[derive(Copy, Clone)]
@@ -87,7 +87,7 @@ impl Editor {
             let mut editor = self.0.borrow_mut();
             let component = &mut editor.component;
             component.push(DomSidecar::new(
-                Line::new(
+                LineSpan::new(
                     (DomText::new(string), (DomBr::new((), factory.br()), ())),
                     factory.span(),
                 ),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -285,10 +285,12 @@ impl Editor {
             let mut editor = self.0.borrow_mut();
             for line in editor.component.iter_mut() {
                 let class = match line.borrow_sidecar().info {
-                    InstrInfo::EmptyOrMalformed => "grey-text",
+                    InstrInfo::EmptyOrMalformed => {
+                        "grey-text"
+                    },
                     _ => {
                         if !line.borrow_sidecar().active {
-                            "grey-text"
+                            "inactive-text"
                         } else {
                             "black-text"
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod utils;
 pub mod web_support;
 
 pub mod editor;
+pub mod line;

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,0 +1,131 @@
+// An individual line of code in the editor. The CodeLine struct
+// enforces consistency between the text in the line, the kind and
+// "is_instr" status of the line (i.e. whether it's a well-formed
+// *and* active instruction), and its CSS presentation.
+
+use crate::{
+    dom_struct::DomStruct,
+    dom_text::DomText,
+    utils::{InstrKind, parse_instr},
+    web_support::{AccessToken, Component, ElementAsNode, ElementFactory, WithElement},
+};
+use anyhow::Result;
+use web_sys::{HtmlBrElement, HtmlSpanElement};
+
+type DomBr = DomStruct<(), HtmlBrElement>;
+type LineContents = (DomText, (DomBr, ()));
+type LineSpan = DomStruct<LineContents, HtmlSpanElement>;
+
+#[derive(Copy, Clone)]
+pub struct LineInfo {
+    pub kind: InstrKind,
+    pub active: bool,
+}
+
+impl LineInfo {
+    pub fn new(kind: InstrKind, active: bool) -> Self {
+        Self { kind, active }
+    }
+
+    pub fn is_instr(&self) -> bool {
+        self.kind != InstrKind::EmptyOrMalformed && self.active
+    }
+}
+
+pub struct CodeLine {
+    contents: LineSpan,
+    info: LineInfo,
+}
+
+impl WithElement for CodeLine {
+    type Element = HtmlSpanElement;
+    fn with_element(&self, f: impl FnMut(&HtmlSpanElement), g: AccessToken) {
+        self.contents.with_element(f, g)
+    }
+}
+
+impl ElementAsNode for CodeLine {}
+
+impl Component for CodeLine {
+    fn audit(&self) {
+        assert_eq!(
+            self.info.kind,
+            parse_instr(self.contents.get().0.get_contents())
+        );
+        assert_eq!(self.contents.get_attribute("class").unwrap(), self.class());
+        self.contents.audit();
+    }
+}
+
+impl CodeLine {
+    fn class(&self) -> &'static str {
+        if self.info.is_instr() {
+            "black-text"
+        } else {
+            "gray-text"
+        }
+    }
+
+    pub fn new(contents: &str, factory: &ElementFactory) -> Self {
+        let mut ret = Self {
+            contents: LineSpan::new(
+                (DomText::new(contents), (DomBr::new((), factory.br()), ())),
+                factory.span(),
+            ),
+            info: LineInfo {
+                kind: parse_instr(contents),
+                active: true,
+            },
+        };
+
+        ret.conform_activity();
+
+        ret
+    }
+
+    // Make the element presentation (CSS class) match the "is_instr" status.
+    // This needs to happen when the active status changes.
+    fn conform_activity(&mut self) {
+        self.contents.set_attribute("class", self.class());
+    }
+
+    // Make the kind and CSS presentation consistent with the text contents.
+    // This needs to happen when the text changes.
+    fn conform_to_text(&mut self) {
+        self.info.kind = parse_instr(self.contents.get().0.get_contents());
+        self.conform_activity();
+    }
+
+    // Activate or deactivate the line.
+    pub fn set_active_status(&mut self, is_active: bool) {
+        if is_active != self.info.active {
+            self.info.active = is_active;
+            self.conform_activity();
+        }
+    }
+
+    pub fn text(&self) -> &DomText {
+        &self.contents.get().0
+    }
+
+    // Modify the contents. This calls replace_range on the inner DomText, then
+    // makes the kind and CSS presentation consistent with the new contents.
+    pub fn replace_range(
+        &mut self,
+        utf16_start_idx: usize,
+        utf16_end_idx: usize,
+        string: &str,
+    ) -> Result<usize> {
+        let pos =
+            self.contents
+                .get_mut()
+                .0
+                .replace_range(utf16_start_idx, utf16_end_idx, string)?;
+        self.conform_to_text();
+        Ok(pos)
+    }
+
+    pub fn info(&self) -> LineInfo {
+        self.info
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ impl Default for OkModule {
 
 impl OkModule {
     //assumes only one function
-    pub fn build(wasm_bin: Vec<u8>, infos: &impl LineInfos) -> Result<Self> {
+    pub fn build(wasm_bin: Vec<u8>, infos: &impl LineInfos, synthetic_ends: usize) -> Result<Self> {
         OkModule::try_new(wasm_bin, |wasm_bin| {
             //first, collect all operators
             let parser = Parser::new(0);
@@ -54,7 +54,7 @@ impl OkModule {
                 while line_idx < infos.len() && !infos.get(line_idx).is_instr() {
                     line_idx += 1;
                 }
-                if line_idx >= infos.len() {
+                if line_idx >= infos.len() + synthetic_ends {
                     bail!("not enough instructions");
                 }
                 ops_with_indices.push((op?, line_idx));
@@ -526,7 +526,7 @@ mod tests {
             LineInfo::new(InstrInfo::End, true),
             LineInfo::new(InstrInfo::Other, true),
         ];
-        let module = OkModule::build(wasm_bin, &infos)?;
+        let module = OkModule::build(wasm_bin, &infos, 0)?;
         assert_eq!(
             collect_operands(module.borrow_binary(), module.borrow_ops())?,
             output
@@ -554,7 +554,7 @@ mod tests {
             LineInfo::new(InstrInfo::End, true),
             LineInfo::new(InstrInfo::Other, true),
         ];
-        let module = OkModule::build(wasm_bin, &infos)?;
+        let module = OkModule::build(wasm_bin, &infos, 0)?;
         assert_eq!(
             collect_operands(module.borrow_binary(), module.borrow_ops())?,
             output
@@ -595,7 +595,7 @@ mod tests {
             LineInfo::new(InstrInfo::End, true),
             LineInfo::new(InstrInfo::Other, true),
         ];
-        let module = OkModule::build(wasm_bin, &infos)?;
+        let module = OkModule::build(wasm_bin, &infos, 0)?;
         assert_eq!(
             collect_operands(module.borrow_binary(), module.borrow_ops())?,
             output
@@ -636,7 +636,7 @@ mod tests {
             LineInfo::new(InstrInfo::End, true),
             LineInfo::new(InstrInfo::Other, true),
         ];
-        let module = OkModule::build(wasm_bin, &infos)?;
+        let module = OkModule::build(wasm_bin, &infos, 0)?;
         assert_eq!(
             collect_operands(module.borrow_binary(), module.borrow_ops())?,
             output
@@ -651,7 +651,7 @@ mod tests {
             LineInfo::new(InstrInfo::OtherStructured, true),
             LineInfo::new(InstrInfo::End, true),
         ];
-        let module = OkModule::build(wasm_bin, &infos)?;
+        let module = OkModule::build(wasm_bin, &infos, 0)?;
         assert_eq!(
             collect_operands(module.borrow_binary(), module.borrow_ops())?,
             output

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -377,7 +377,7 @@ mod tests {
             &mut self[index]
         }
 
-        fn set_attribute(&mut self, index: usize, name: &str, value: &str) {}
+        fn set_attribute(&mut self, _index: usize, _name: &str, _value: &str) {}
     }
 
     #[test]

--- a/src/web_support.rs
+++ b/src/web_support.rs
@@ -169,6 +169,10 @@ impl<T: AnyElement> ElementHandle<T> {
         self.elem.element().set_attribute(name, value).unwrap();
     }
 
+    pub fn get_attribute(&self, name: &str) -> Option<&String> {
+        self.attributes.get(name)
+    }
+
     pub fn audit(&self) {
         for (key, value) in &self.attributes {
             if let Some(dom_value) = self.elem.element().get_attribute(key) {


### PR DESCRIPTION
This PR:
- colors empty, malformed, and inactive lines grey
- addresses error thrown by OkModule build function when there are synthetic ends (only panic about "not enough instructions" when there are more operators than there are instructions + synthetic ends)
