### PR TITLE
Support multi-line operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ delegate = "0.13.4"
 js-sys = "0.3.77"
 str_indices = "0.4.4"
 wasm-bindgen = "0.2.100"
-web-sys = { version = "0.3.77", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer"] }
+web-sys = { version = "0.3.77", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer", "KeyboardEvent", "ScrollIntoViewOptions", "ScrollBehavior", "ScrollLogicalPosition"] }
 self_cell = "1.2.0"
 
 [patch.crates-io]

--- a/public/codillon.css
+++ b/public/codillon.css
@@ -47,10 +47,12 @@ div.textentry:focus {
 .empty-line {
     color: gray;
 }
-.good-line { color: black; }
+.good-line {
+    color: black;
+    counter-increment: codelines;
+}
 
 .malformed-line::before {
-    counter-increment: codelines;
     font-size: 20pt;
     color: darkred;
     display: inline-block;
@@ -61,7 +63,6 @@ div.textentry:focus {
 }
 
 .inactive-line::before {
-    counter-increment: codelines;
     font-size: 20pt;
     color: gray;
     display: inline-block;
@@ -72,7 +73,6 @@ div.textentry:focus {
 }
 
 .empty-line::before {
-    counter-increment: codelines;
     font-size: 20pt;
     color: gray;
     display: inline-block;
@@ -83,7 +83,6 @@ div.textentry:focus {
 }
 
 .good-line::before {
-    counter-increment: codelines;
     font-size: 20pt;
     color: gray;
     display: inline-block;
@@ -99,7 +98,7 @@ span.comment {
     font-size: 18pt;
 }
 
-span.malformed-line span.comment::after {
+div.malformed-line span.comment::after {
     font-family: 'MLMRoman10-Regular';
     font-size: 12pt;
     color: darkred;
@@ -107,6 +106,7 @@ span.malformed-line span.comment::after {
     text-align: right;
     border: 1px solid darkred;
     padding: 4px;
+    margin-top: 10px;
 
     content: attr(data-commentary);
 }

--- a/src/dom_struct.rs
+++ b/src/dom_struct.rs
@@ -74,8 +74,11 @@ impl<Child: Structure, Element: AnyElement> DomStruct<Child, Element> {
     delegate! {
     to self.elem {
     pub fn set_attribute(&mut self, name: &str, value: &str);
+    pub fn remove_attribute(&mut self, name: &str);
     pub fn get_attribute(&self, name: &str) -> Option<&String>;
     pub fn set_onbeforeinput<F: Fn(InputEventHandle) + 'static>(&mut self, handler: F);
+    pub fn set_onkeydown<F: Fn(web_sys::KeyboardEvent) + 'static>(&mut self, handler: F);
+    pub fn scroll_into_view(&self);
     }
     }
 }

--- a/src/dom_text.rs
+++ b/src/dom_text.rs
@@ -23,11 +23,6 @@ impl DomText {
         self.text_node.append_data(string);
     }
 
-    pub fn set_data_owned(&mut self, string: String) {
-        self.contents = string;
-        self.text_node.set_data(&self.contents);
-    }
-
     pub fn set_data(&mut self, string: &str) {
         self.contents = string.to_string();
         self.text_node.set_data(string);
@@ -57,7 +52,7 @@ impl DomText {
         Ok(byte_idx)
     }
 
-    fn safe_byte_idx_to_utf16(&self, byte_idx: usize) -> Result<usize> {
+    pub fn safe_byte_idx_to_utf16(&self, byte_idx: usize) -> Result<usize> {
         let utf16_idx = str_indices::utf16::from_byte_idx(&self.contents, byte_idx);
 
         if byte_idx != str_indices::utf16::to_byte_idx(&self.contents, utf16_idx) {
@@ -121,8 +116,13 @@ impl DomText {
         self.contents.is_empty()
     }
 
-    pub fn get_contents(&self) -> &str {
+    pub fn get(&self) -> &str {
         &self.contents
+    }
+
+    pub fn suffix_utf16(&self, utf16_start_idx: usize) -> Result<&str> {
+        let byte_start_idx = self.safe_utf16_to_byte_idx(utf16_start_idx)?;
+        Ok(&self.contents[byte_start_idx..])
     }
 }
 

--- a/src/dom_vec.rs
+++ b/src/dom_vec.rs
@@ -23,8 +23,23 @@ impl<Child: Component, Element: AnyElement> DomVec<Child, Element> {
         self.elem.append_node(self.contents.last().unwrap());
     }
 
+    pub fn insert(&mut self, index: usize, elem: Child) {
+        if index == self.contents.len() {
+            self.push(elem)
+        } else if index < self.contents.len() {
+            self.contents.insert(index, elem);
+            self.elem.insert_node(index, &self.contents[index]);
+        } else {
+            panic!("index > len");
+        }
+    }
+
     pub fn remove(&mut self, index: usize) -> Child {
         self.contents.remove(index)
+    }
+
+    pub fn remove_range(&mut self, begin: usize, end: usize) {
+        self.contents.drain(begin..end);
     }
 
     pub fn set_contents(&mut self, elem: Child) {
@@ -44,8 +59,12 @@ impl<Child: Component, Element: AnyElement> DomVec<Child, Element> {
             F: FnMut(&'a Child) -> std::cmp::Ordering;
     }
     to self.elem {
-        pub fn set_attribute(&mut self, name: &str, value: &str);
+    pub fn set_attribute(&mut self, name: &str, value: &str);
+    pub fn remove_attribute(&mut self, name: &str);
+    pub fn get_attribute(&self, name: &str) -> Option<&String>;
     pub fn set_onbeforeinput<F: Fn(InputEventHandle) + 'static>(&mut self, handler: F);
+    pub fn set_onkeydown<F: Fn(web_sys::KeyboardEvent) + 'static>(&mut self, handler: F);
+    pub fn scroll_into_view(&self);
     }
     }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -13,12 +13,11 @@ use crate::{
     },
 };
 use anyhow::{Result, bail};
-use web_sys::{HtmlBrElement, HtmlSpanElement, Text};
+use web_sys::{HtmlBrElement, HtmlDivElement, HtmlSpanElement};
 
 type DomBr = DomStruct<(), HtmlBrElement>;
 type Comment = DomStruct<(DomText, ()), HtmlSpanElement>;
-type LineContents = (DomText, (Comment, (DomBr, ())));
-type LineSpan = DomStruct<LineContents, HtmlSpanElement>;
+type LinePara = DomStruct<(DomText, (Comment, (DomBr, ()))), HtmlDivElement>;
 
 pub struct LineInfo {
     pub kind: InstrKind,
@@ -36,42 +35,42 @@ impl LineInfo {
 }
 
 pub struct CodeLine {
-    contents: LineSpan,
+    contents: LinePara,
     info: LineInfo,
 }
 
 impl WithElement for CodeLine {
-    type Element = HtmlSpanElement;
-    fn with_element(&self, f: impl FnMut(&HtmlSpanElement), g: AccessToken) {
+    type Element = HtmlDivElement;
+    fn with_element(&self, f: impl FnMut(&HtmlDivElement), g: AccessToken) {
         self.contents.with_element(f, g)
     }
 }
 
 impl ElementAsNode for CodeLine {}
 
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Position {
     Instr(usize),
     Comment(usize),
 }
 
+impl Position {
+    pub fn begin() -> Position {
+        Position::Instr(0)
+    }
+}
+
 impl Component for CodeLine {
     fn audit(&self) {
-        assert_eq!(
-            self.info.kind,
-            parse_instr(self.contents.get().0.get_contents())
-        );
+        assert_eq!(self.info.kind, parse_instr(self.contents.get().0.get()));
         assert_eq!(self.contents.get_attribute("class").unwrap(), self.class());
         assert_eq!(
             self.contents.get().1.0.get_attribute("data-commentary"),
-            Some(
-                if let InstrKind::Malformed(reason) = &self.info.kind {
-                    reason
-                } else {
-                    ""
-                }
-                .to_string()
-            )
-            .as_ref()
+            if let InstrKind::Malformed(reason) = &self.info.kind {
+                Some(reason)
+            } else {
+                None
+            }
         );
 
         self.contents.audit();
@@ -95,10 +94,6 @@ impl CodeLine {
         &mut self.contents.get_mut().1.0.get_mut().0
     }
 
-    pub fn begin_position() -> Position {
-        Position::Instr(0)
-    }
-
     pub fn end_position(&self) -> Position {
         if self.comment().is_empty() {
             Position::Instr(self.instr().len_utf16())
@@ -112,41 +107,38 @@ impl CodeLine {
 
         let instr_end = Instr(self.instr().len_utf16());
 
-        // If the position is in the top-level span element, the offset counts nodes
-        // within the span.
+        // If the position is in the top-level div element, the offset counts nodes
+        // within the line.
         if node.is_same_node(&self.contents) {
-            debug_assert!(node.is_a::<HtmlSpanElement>());
             return Ok(match offset {
-                0 => Self::begin_position(),
+                0 => Position::begin(),
                 1 => instr_end,
                 _ => self.end_position(),
             });
         }
 
-        // Position in "instruction" or "comment" text nodes.
+        // Position in instruction, comment, or newline text nodes.
         if node.is_same_node(self.instr()) {
-            debug_assert!(node.is_a::<Text>());
             if offset > self.instr().len_utf16() {
                 bail!("invalid offset");
             }
             return Ok(Instr(offset));
         } else if node.is_same_node(self.comment()) {
-            debug_assert!(node.is_a::<Text>());
             if offset > self.comment().len_utf16() {
                 bail!("invalid offset");
             }
-            return match offset {
-                0 => Ok(instr_end),
-                _ => Ok(Comment(offset)),
-            };
+            return Ok(match offset {
+                0 => instr_end,
+                _ => Comment(offset),
+            });
         }
 
         // Position in the "comment" span.
         if node.is_same_node(&self.contents.get().1.0) {
-            debug_assert!(node.is_a::<HtmlSpanElement>());
             return Ok(match offset {
                 0 => instr_end,
-                _ => self.end_position(),
+                1 => self.end_position(),
+                _ => bail!("unexpected comment span position {offset}"),
             });
         }
 
@@ -167,7 +159,7 @@ impl CodeLine {
 
     pub fn new(contents: &str, factory: &ElementFactory) -> Self {
         let mut ret = Self {
-            contents: LineSpan::new(
+            contents: LinePara::new(
                 (
                     DomText::new(contents),
                     (
@@ -175,7 +167,7 @@ impl CodeLine {
                         (DomBr::new((), factory.br()), ()),
                     ),
                 ),
-                factory.span(),
+                factory.div(),
             ),
             info: LineInfo {
                 kind: InstrKind::Empty,
@@ -196,20 +188,26 @@ impl CodeLine {
     }
 
     fn conform_commentary(&mut self) {
-        self.contents.get_mut().1.0.set_attribute(
-            "data-commentary",
-            if let InstrKind::Malformed(reason) = &self.info.kind {
-                reason
-            } else {
-                ""
-            },
-        )
+        if let InstrKind::Malformed(reason) = &self.info.kind {
+            self.contents
+                .get_mut()
+                .1
+                .0
+                .set_attribute("data-commentary", reason);
+        } else {
+            self.contents
+                .get_mut()
+                .1
+                .0
+                .remove_attribute("data-commentary");
+        }
     }
 
     // Make the instr/comment split, the kind, and the CSS presentation consistent with the text contents.
     // This needs to happen when the text changes. Returns number of whitespace bytes trimmed from start.
     fn conform_to_text(&mut self) -> Result<usize> {
-        match find_comment(self.instr().get_contents(), self.comment().get_contents()) {
+        // Re-split text nodes at beginning of line comment (if any)
+        match find_comment(self.instr().get(), self.comment().get()) {
             None if self.comment().is_empty() => {}
             None => {
                 let comment = self.comment_mut().take();
@@ -217,16 +215,23 @@ impl CodeLine {
             }
             Some(x) if x == self.instr().len_bytes() => {}
             Some(x) => {
-                let concat = self.instr().get_contents().to_owned() + self.comment().get_contents();
+                let concat = self.instr().get().to_owned() + self.comment().get();
                 self.instr_mut().set_data(&concat[0..x]);
                 self.comment_mut().set_data(&concat[x..]);
             }
         }
-        let ws_bytes = self.instr().len_bytes() - self.instr().get_contents().trim_start().len();
+        // Trim whitespace at front of instruction
+        let ws_bytes = self.instr().len_bytes()
+            - self
+                .instr()
+                .get()
+                .trim_start_matches(|x: char| x.is_whitespace() && x != '\n')
+                .len();
         if ws_bytes != 0 {
             self.instr_mut().replace_range_bytes(0, ws_bytes, "")?;
         }
-        self.info.kind = parse_instr(self.instr().get_contents());
+        // Update kind, commentary, and active status
+        self.info.kind = parse_instr(self.instr().get());
         self.conform_commentary();
         self.conform_activity();
         Ok(ws_bytes)
@@ -238,6 +243,26 @@ impl CodeLine {
             self.info.active = is_active;
             self.conform_activity();
         }
+    }
+
+    pub fn suffix(&self, pos: Position) -> Result<String> {
+        use Position::*;
+
+        Ok(match pos {
+            Instr(a) => String::from(self.instr().suffix_utf16(a)?) + self.comment().get(),
+            Comment(b) => self.comment().suffix_utf16(b)?.to_string(),
+        })
+    }
+
+    pub fn first_newline(&self) -> Result<Option<Position>> {
+        use Position::*;
+        Ok(if let Some(idx) = self.instr().get().find('\n') {
+            Some(Instr(self.instr().safe_byte_idx_to_utf16(idx)?))
+        } else if let Some(idx) = self.comment().get().find('\n') {
+            Some(Comment(self.comment().safe_byte_idx_to_utf16(idx)?))
+        } else {
+            None
+        })
     }
 
     // Modify the contents. This calls replace_range on one of the inner DomTexts (or both), then
@@ -255,11 +280,12 @@ impl CodeLine {
             (Comment(a), Comment(b)) => {
                 self.instr().len_utf16() + self.comment_mut().replace_range(a, b, string)?
             }
-            (Instr(a), Comment(b)) | (Comment(b), Instr(a)) => {
+            (Instr(a), Comment(b)) => {
                 self.comment_mut().replace_range(0, b, "")?;
                 let instr_len = self.instr().len_utf16();
                 self.instr_mut().replace_range(a, instr_len, string)?
             }
+            (Comment(_), Instr(_)) => bail!("unhandled comment -> instr range"),
         };
 
         total_pos = total_pos.saturating_sub(self.conform_to_text()?);
@@ -280,6 +306,8 @@ impl CodeLine {
             Instr(offset) => set_cursor_position(self.instr(), offset),
             Comment(offset) => set_cursor_position(self.comment(), offset),
         }
+
+        self.contents.scroll_into_view();
     }
 
     pub fn info(&self) -> &LineInfo {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ thread_local! {
 fn setup() -> Result<()> {
     DOCUMENT.with_borrow_mut(|doc| {
         let factory = doc.element_factory();
-        doc.set_body(Body::new((Editor::new(&factory), ()), factory.body()));
+        let body = factory.body();
+        doc.set_body(Body::new((Editor::new(factory), ()), body));
         doc.audit();
     });
 


### PR DESCRIPTION
This approach seems to work relatively smoothly in Firefox and Chrome. Unfortunately it seems very sensitive to the particular choice of HTML elements to represent the lines (e.g. div vs. div-with-br vs. span-with-br vs. span-with-"\n").