### PR TITLE
Represent malformed modules, and enforce staying on the "culprit" line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ delegate = "0.13.4"
 js-sys = "0.3.77"
 str_indices = "0.4.4"
 wasm-bindgen = "0.2.100"
-web-sys = { version = "0.3.77", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer", "KeyboardEvent", "ScrollIntoViewOptions", "ScrollBehavior", "ScrollLogicalPosition"] }
+web-sys = { version = "0.3.77", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer", "KeyboardEvent", "ScrollIntoViewOptions", "ScrollBehavior", "ScrollLogicalPosition", "MouseEvent"] }
 self_cell = "1.2.0"
 
 [patch.crates-io]

--- a/public/codillon.css
+++ b/public/codillon.css
@@ -30,7 +30,7 @@ div.textentry {
     counter-reset: codelines;
 }
 
-div.textentry:focus {
+:focus {
     outline: none;
     box-shadow: none;
 }
@@ -38,6 +38,43 @@ div.textentry:focus {
 .malformed-line {
     color: gray;
 }
+
+.culprit-line {
+    color: darkred;
+    border: 0.5px dashed darkred;
+    margin: -0.5px;
+}
+
+.culprit-line-a {
+    color: darkred;
+    border: 0.5px dashed darkred;
+    margin: -0.5px;
+    animation: shake-a 0.25s;
+}
+
+.culprit-line-b {
+    color: darkred;
+    border: 0.5px dashed darkred;
+    margin: -0.5px;
+    animation: shake-b 0.25s;
+}
+
+@keyframes shake-a {
+ 0% { transform: translateX(0) }
+ 25% { transform: translateX(5px) }
+ 50% { transform: translateX(-5px) }
+ 75% { transform: translateX(5px) }
+ 100% { transform: translateX(0) }
+}
+
+@keyframes shake-b {
+ 0% { transform: translateX(0) }
+ 25% { transform: translateX(5px) }
+ 50% { transform: translateX(-5px) }
+ 75% { transform: translateX(5px) }
+ 100% { transform: translateX(0) }
+}
+
 .inactive-line { 
     color: gray;
     text-decoration: underline;
@@ -50,6 +87,16 @@ div.textentry:focus {
 .good-line {
     color: black;
     counter-increment: codelines;
+}
+
+.culprit-line::before {
+    font-size: 20pt;
+    color: darkred;
+    display: inline-block;
+    width: 2em;
+    text-align: right;
+
+    content: "\1d11e    ";
 }
 
 .malformed-line::before {
@@ -99,6 +146,19 @@ span.comment {
 }
 
 div.malformed-line span.comment::after {
+    font-family: 'MLMRoman10-Regular';
+    font-size: 12pt;
+    color: darkred;
+    float: right;
+    text-align: right;
+    border: 1px solid darkred;
+    padding: 4px;
+    margin-top: 10px;
+
+    content: attr(data-commentary);
+}
+
+div.culprit-line span.comment::after {
     font-family: 'MLMRoman10-Regular';
     font-size: 12pt;
     color: darkred;

--- a/src/dom_struct.rs
+++ b/src/dom_struct.rs
@@ -3,7 +3,7 @@
 
 use crate::web_support::{
     AccessToken, AnyElement, ArrayHandle, Component, ElementAsNode, ElementHandle,
-    InputEventHandle, NodeListHandle, WithElement,
+    InputEventHandle, MouseEventHandle, NodeListHandle, WithElement,
 };
 use delegate::delegate;
 
@@ -78,6 +78,7 @@ impl<Child: Structure, Element: AnyElement> DomStruct<Child, Element> {
     pub fn get_attribute(&self, name: &str) -> Option<&String>;
     pub fn set_onbeforeinput<F: Fn(InputEventHandle) + 'static>(&mut self, handler: F);
     pub fn set_onkeydown<F: Fn(web_sys::KeyboardEvent) + 'static>(&mut self, handler: F);
+    pub fn set_onmousedown<F: Fn(MouseEventHandle) + 'static>(&mut self, handler: F);
     pub fn scroll_into_view(&self);
     }
     }

--- a/src/dom_vec.rs
+++ b/src/dom_vec.rs
@@ -1,7 +1,8 @@
 // A Codillon DOM "vector": a variable-length collection of Components of the same type
 
 use crate::web_support::{
-    AccessToken, AnyElement, Component, ElementAsNode, ElementHandle, InputEventHandle, WithElement,
+    AccessToken, AnyElement, Component, ElementAsNode, ElementHandle, InputEventHandle,
+    MouseEventHandle, WithElement,
 };
 use delegate::delegate;
 
@@ -64,6 +65,7 @@ impl<Child: Component, Element: AnyElement> DomVec<Child, Element> {
     pub fn get_attribute(&self, name: &str) -> Option<&String>;
     pub fn set_onbeforeinput<F: Fn(InputEventHandle) + 'static>(&mut self, handler: F);
     pub fn set_onkeydown<F: Fn(web_sys::KeyboardEvent) + 'static>(&mut self, handler: F);
+    pub fn set_onmousedown<F: Fn(MouseEventHandle) + 'static>(&mut self, handler: F);
     pub fn scroll_into_view(&self);
     }
     }


### PR DESCRIPTION
Hopefully these cases are rare (and we can make them rarer by detecting and fixing the issues), but this provides a way to deal with the cases that we don't handle.

One example is a line that says:
```wasm
br $x
```

where there is no `$x` label defined.