### PR TITLE
encode by instructions, add execution limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "str_indices",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-encoder",
  "wasm-tools",
  "wasmparser",
  "wasmprinter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ wasm-bindgen = "0.2.104"
 web-sys = { version = "0.3.81", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer", "KeyboardEvent", "ScrollIntoViewOptions", "ScrollBehavior", "ScrollLogicalPosition"] }
 self_cell = "1.2.0"
 wasm-bindgen-futures = "0.4.54"
+wasm-encoder = { version = "0.239.0", features = ["wasmparser"] }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -341,14 +341,14 @@ impl Editor {
             .instructions_as_text()
             .fold(String::new(), |acc, elem| acc + "\n" + elem.as_ref());
         let wasm_bin = str_to_binary(text)?;
-        Self::execute(&wasm_bin);
-        self.0.borrow_mut().module = OkModule::build(wasm_bin, self)?;
 
         // log instruction types (TODO: integrate into OkModule)
         let _ = collect_operands(
             self.0.borrow().module.borrow_binary(),
             self.0.borrow().module.borrow_ops(),
         );
+        self.0.borrow_mut().module = OkModule::build(wasm_bin, self)?;
+        Self::execute(&self.0.borrow().module.build_executable_binary()?);
 
         #[cfg(debug_assertions)]
         {


### PR DESCRIPTION
uses wasm_encoder to translate wasmparser Operations to instructions.
adds a global and instrumentation to ensure the total number of executed instruction steps in a module is less than some constant (1k curently) and to trap if the limit is exceeded