### PR TITLE
editor: improve ergonomics when adding or removing comments

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -130,6 +130,7 @@ impl Editor {
         let mut new_cursor_pos = if start_line == end_line {
             // Single-line edit.
             let was_structured = self.line(start_line).info().is_structured();
+            let old_instr = self.line(start_line).instr().get().to_string();
             // Do the replacement.
             let new_pos = self
                 .line_mut(start_line)
@@ -139,7 +140,10 @@ impl Editor {
             let is_structured = self.line(start_line).info().is_structured();
             let is_if = self.line(start_line).info().kind == InstrKind::If;
 
-            if !was_structured && is_structured {
+            if !was_structured
+                && is_structured
+                && !old_instr.starts_with(self.line(start_line).instr().get())
+            {
                 // search for existing deactivated matching `end` (or `else` if the new instr is `if`)
                 let mut need_end = true;
                 for i in start_line + 1..self.text().len() {


### PR DESCRIPTION
1. On one ";" keystroke at the end of an instruction, add the whole ";;" comment separator.

2. Ignore the subsequent ";" keystroke (so typing two semicolons gets two semicolons).

3. One deletion at the end of a comment that only contains ";;" deletes the whole separator.

4. Adding a courtesy "end" only happens if the new structured instruction's text wasn't already there beforehand (and the only change was the instruction becoming well-formed because something else was removed, e.g. a partial comment).