### PR TITLE
Simple canvas with importable $draw_point function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ delegate = "0.13.5"
 js-sys = "0.3.85"
 str_indices = "0.4.4"
 wasm-bindgen = "0.2.108"
-web-sys = { version = "0.3.85", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer", "KeyboardEvent", "ScrollIntoViewOptions", "ScrollBehavior", "ScrollLogicalPosition", "SvgElement", "SvgLineElement", "SvgDefsElement", "SvgMarkerElement", "SvggElement", "SvgCircleElement", "SvgUseElement", "SvgPathElement", "HtmlInputElement", "Performance"] }
+web-sys = { version = "0.3.85", features = ["Text", "Element", "HtmlDivElement", "Window", "Document", "console", "HtmlBodyElement", "NodeList", "HtmlBrElement", "HtmlSpanElement", "HtmlParagraphElement", "HtmlElement", "InputEvent", "Range", "Selection", "DataTransfer", "KeyboardEvent", "ScrollIntoViewOptions", "ScrollBehavior", "ScrollLogicalPosition", "SvgElement", "SvgLineElement", "SvgDefsElement", "SvgMarkerElement", "SvggElement", "SvgCircleElement", "SvgUseElement", "SvgPathElement", "HtmlInputElement", "HtmlCanvasElement", "CanvasRenderingContext2d", "Performance"] }
 wasm-bindgen-futures = "0.4.58"
 wasm-encoder = { version = "0.245.0", features = ["wasmparser"] }
 

--- a/public/codillon.css
+++ b/public/codillon.css
@@ -265,3 +265,11 @@ span.debug[data-debug]::after {
     cursor: pointer;
     box-shadow: none;
 }
+
+.graph-canvas {
+    background-color: #fff;
+    display: block; 
+    border: 1px solid darkred;
+    margin-left: auto;
+    margin-right: auto;
+}


### PR DESCRIPTION
### PR Description

- Created a helper $draw_point function to record x and y coordinates of points as f64
- Added a simple canvas where points can be drawn with coordinates between -1.0 and 1.0 (closes #115 )

### Minsky's Algorithm Demonstration
<img width="1007" height="488" src="https://github.com/user-attachments/assets/210fdcec-ae28-434a-8978-037505d7355d" />
<img width="1378" height="755" alt="Screenshot 2026-02-21 at 1 41 38 AM" src="https://github.com/user-attachments/assets/6bf960c6-26eb-4378-9627-0a36391bdeec" />

Minskey's Algorithm Sample Code:
(func $draw_point (import "helpers" "draw_point") (param f64 f64))
(global $tau f64 (f64.const 6.283185307179586))
(func
f64.const 100.0
call $draw_circle
)
(func $draw_circle
(param $n f64)
(local $x f64)
(local $y f64)
(local $d f64)
(local $i f64)
f64.const 0.9
local.set $x
f64.const 0.0
local.set $y
global.get $tau
local.get $n
f64.div
local.set $d
loop $circle
local.get $x
local.get $y
call $draw_point
local.get $x
local.get $y
local.get $d
f64.mul
f64.add
local.set $x
local.get $y
local.get $x
local.get $d
f64.mul
f64.sub
local.set $y
local.get $i
f64.const 1
f64.add 
local.set $i
local.get $i
local.get $n
f64.lt
br_if $circle
end
)