### PR TITLE
Disable lines that define duplicate symbolics

### DIFF
--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -27,23 +27,6 @@ enum IndexSpace {
     Undefined,
 }
 
-impl IndexSpace {
-    fn as_str(&self) -> &'static str {
-        match self {
-            IndexSpace::Type => "type",
-            IndexSpace::Global => "global",
-            IndexSpace::Mem => "memory",
-            IndexSpace::Table => "table",
-            IndexSpace::Func => "func",
-            IndexSpace::Data => "data",
-            IndexSpace::Elem => "elem",
-            IndexSpace::Local => "local",
-            IndexSpace::Label => "label",
-            IndexSpace::Undefined => "undefined",
-        }
-    }
-}
-
 impl From<ExportKind> for IndexSpace {
     fn from(kind: ExportKind) -> Self {
         match kind {
@@ -142,34 +125,29 @@ impl LineSymbols {
 pub fn collect_module_symbols(
     line_symbols: &LineSymbols,
     identifiers: &mut ModuleIdentifiers,
-) -> Result<(), String> {
+) -> Result<(), &'static str> {
     for symbol in &line_symbols.defines {
         if let Some(set) = identifiers.set_mut(&symbol.space)
             && !set.insert(symbol.name.clone())
         {
-            return Err(format!(
-                "duplicate {} symbol: ${}",
-                symbol.space.as_str(),
-                symbol.name
-            ));
+            return Err("duplicate symbol in same index space");
         }
     }
     Ok(())
 }
 
 // Collect function-scoped defined Local symbols, disgard non-local symbols without err
-// Returns an error if a symbol is a duplicate within the local
+// Returns an error if a symbol is a duplicate within that function scope
 pub fn collect_local_symbols(
     line_symbols: &LineSymbols,
     locals: &mut HashSet<String>,
-) -> Result<(), String> {
+) -> Result<(), &'static str> {
     for symbol in &line_symbols.defines {
-        if symbol.space == IndexSpace::Local && !locals.insert(symbol.name.clone()) {
-            return Err(format!(
-                "duplicate {} symbol: ${}",
-                symbol.space.as_str(),
-                symbol.name
-            ));
+        if symbol.space != IndexSpace::Local {
+            continue;
+        }
+        if !locals.insert(symbol.name.clone()) {
+            return Err("duplicate local symbol");
         }
     }
     Ok(())

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -136,7 +136,7 @@ pub fn collect_module_symbols(
                 for (space, name) in inserted {
                     identifiers.set_mut(space).unwrap().remove(name);
                 }
-                return Err("duplicate symbol in same index space");
+                return Err("duplicate symbolic reference in same index space");
             }
             inserted.push((&symbol.space, &symbol.name));
         }
@@ -163,7 +163,7 @@ pub fn collect_local_symbols(
             for name in inserted {
                 locals.remove(name);
             }
-            return Err("duplicate local symbol");
+            return Err("duplicate local symbolic reference");
         }
         inserted.push(&symbol.name);
     }

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -27,6 +27,23 @@ enum IndexSpace {
     Undefined,
 }
 
+impl IndexSpace {
+    fn as_str(&self) -> &'static str {
+        match self {
+            IndexSpace::Type => "type",
+            IndexSpace::Global => "global",
+            IndexSpace::Mem => "memory",
+            IndexSpace::Table => "table",
+            IndexSpace::Func => "func",
+            IndexSpace::Data => "data",
+            IndexSpace::Elem => "elem",
+            IndexSpace::Local => "local",
+            IndexSpace::Label => "label",
+            IndexSpace::Undefined => "undefined",
+        }
+    }
+}
+
 impl From<ExportKind> for IndexSpace {
     fn from(kind: ExportKind) -> Self {
         match kind {
@@ -120,25 +137,45 @@ impl LineSymbols {
     }
 }
 
-/// Collect module-level defined symbols
-pub fn collect_module_symbols(line_symbols: &LineSymbols, identifiers: &mut ModuleIdentifiers) {
+// Collect module-level defined symbols, disgard non-module-level symbols without err
+// Returns an error if a symbol is a duplicate within its index space
+pub fn collect_module_symbols(
+    line_symbols: &LineSymbols,
+    identifiers: &mut ModuleIdentifiers,
+) -> Result<(), String> {
     for symbol in &line_symbols.defines {
-        if let Some(set) = identifiers.set_mut(&symbol.space) {
-            set.insert(symbol.name.clone());
+        if let Some(set) = identifiers.set_mut(&symbol.space)
+            && !set.insert(symbol.name.clone())
+        {
+            return Err(format!(
+                "duplicate {} symbol: ${}",
+                symbol.space.as_str(),
+                symbol.name
+            ));
         }
     }
+    Ok(())
 }
 
-// Collect function-scoped defined Local symbols
-pub fn collect_local_symbols(line_symbols: &LineSymbols, locals: &mut HashSet<String>) {
+// Collect function-scoped defined Local symbols, disgard non-local symbols without err
+// Returns an error if a symbol is a duplicate within the local
+pub fn collect_local_symbols(
+    line_symbols: &LineSymbols,
+    locals: &mut HashSet<String>,
+) -> Result<(), String> {
     for symbol in &line_symbols.defines {
-        if symbol.space == IndexSpace::Local {
-            locals.insert(symbol.name.clone());
+        if symbol.space == IndexSpace::Local && !locals.insert(symbol.name.clone()) {
+            return Err(format!(
+                "duplicate {} symbol: ${}",
+                symbol.space.as_str(),
+                symbol.name
+            ));
         }
     }
+    Ok(())
 }
 
-// Return the label defined in the line, if there's any
+// Return the label defined in the line, if there's any, ignoring non-label symbols
 pub fn collect_label_symbol(line_symbols: &LineSymbols) -> Option<String> {
     assert!(line_symbols.defines.len() <= 1);
 

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -120,40 +120,58 @@ impl LineSymbols {
     }
 }
 
-// Collect module-level defined symbols, disgard non-module-level symbols without err
-// Returns an error if a symbol is a duplicate within its index space
+// Collect module-level defined symbols; no action for non-module-level symbols.
+// Returns an error and revert the collection if any line symbol is a duplicate within
+// its index space.
 pub fn collect_module_symbols(
     line_symbols: &LineSymbols,
     identifiers: &mut ModuleIdentifiers,
 ) -> Result<(), &'static str> {
+    let mut inserted: Vec<(&IndexSpace, &str)> = Vec::new();
+
     for symbol in &line_symbols.defines {
-        if let Some(set) = identifiers.set_mut(&symbol.space)
-            && !set.insert(symbol.name.clone())
-        {
-            return Err("duplicate symbol in same index space");
+        if let Some(set) = identifiers.set_mut(&symbol.space) {
+            if !set.insert(symbol.name.clone()) {
+                // Revert collections and return with err
+                for (space, name) in inserted {
+                    identifiers.set_mut(space).unwrap().remove(name);
+                }
+                return Err("duplicate symbol in same index space");
+            }
+            inserted.push((&symbol.space, &symbol.name));
         }
     }
+
     Ok(())
 }
 
-// Collect function-scoped defined Local symbols, disgard non-local symbols without err
-// Returns an error if a symbol is a duplicate within that function scope
+// Collect function-scoped defined Local symbols; no action for non-local symbols.
+// Returns an error and revert the collection if any line symbol is a duplicate within
+// that function scope.
 pub fn collect_local_symbols(
     line_symbols: &LineSymbols,
     locals: &mut HashSet<String>,
 ) -> Result<(), &'static str> {
+    let mut inserted: Vec<&str> = Vec::new();
+
     for symbol in &line_symbols.defines {
         if symbol.space != IndexSpace::Local {
             continue;
         }
         if !locals.insert(symbol.name.clone()) {
+            // Revert collections and return with err
+            for name in inserted {
+                locals.remove(name);
+            }
             return Err("duplicate local symbol");
         }
+        inserted.push(&symbol.name);
     }
+
     Ok(())
 }
 
-// Return the label defined in the line, if there's any, ignoring non-label symbols
+// Return the label defined in the line, if there's any, ignoring non-label symbols.
 pub fn collect_label_symbol(line_symbols: &LineSymbols) -> Option<String> {
     assert!(line_symbols.defines.len() <= 1);
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -656,7 +656,13 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                 before_imports = false;
             }
 
-            collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
+            // Collect module-level symbols
+            let collect_result =
+                collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
+            if let Err(reason) = collect_result {
+                lines.set_active_status(line_no, Inactive(reason.leak()));
+                continue;
+            }
         }
     }
 
@@ -789,7 +795,12 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
         // Collect defined local symbolic references if there's any
         if lines.info(line_no).is_active() {
-            collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
+            let collect_result =
+                collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
+            if let Err(reason) = collect_result {
+                lines.set_active_status(line_no, Inactive(reason.leak()));
+                continue;
+            }
         }
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -670,9 +670,8 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     for line_no in 0..lines.len() {
         let line_kind = lines.info(line_no).kind.stripped_clone();
 
-        // Handle symbolic reference (check consumption & collect local symbols)
+        // Enforce correct symbolic reference consumption
         if lines.info(line_no).is_active() {
-            // Enforce correct symbolic reference consumption
             // end/else must match the label of the frame being closed, not any enclosing frame
             let label_symbol_defs: Vec<String> = match line_kind {
                 LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => frame_stack
@@ -693,19 +692,6 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             ) {
                 lines.set_active_status(line_no, Inactive("undefined symbolic reference"));
                 continue;
-            }
-
-            // Try to collect local symbols if the line "just in" the function header
-            if matches!(
-                state,
-                SyntaxState::Initial | SyntaxState::AfterFuncHeader(_)
-            ) {
-                let collect_result =
-                    collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
-                if let Err(reason) = collect_result {
-                    lines.set_active_status(line_no, Inactive(reason));
-                    continue;
-                }
             }
         }
 
@@ -743,10 +729,8 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
         }
 
         // Process the line and transition the syntax state
-        // Every invalidations for module parts should go before the state transition,
-        // since those line shouldn't trigger the state transition
+        let orig_state = state;
         {
-            let orig_state = state;
             let res = state.transit_state(&lines.info(line_no), |_| {});
             match res {
                 Ok(()) => {
@@ -807,6 +791,19 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                 ),
                 InstrKind::Other => (),
             }
+        }
+
+        // Collect defined local symbolic references if there's any.
+        // This collection should be after the state transition, because both of them can
+        // inactivate a line and need to revert the state and/or remove collected symbols after 
+        // the inactivation. Reverting state is much simpler than removing symbols.
+        let collect_result =
+            collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
+        if let Err(reason) = collect_result {
+            // Inactivate line and revert state
+            lines.set_active_status(line_no, Inactive(reason));
+            state = orig_state;
+            continue;
         }
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -795,15 +795,17 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
         // Collect defined local symbolic references if there's any.
         // This collection should be after the state transition, because both of them can
-        // inactivate a line and need to revert the state and/or remove collected symbols after 
+        // inactivate a line and need to revert the state and/or remove collected symbols after
         // the inactivation. Reverting state is much simpler than removing symbols.
-        let collect_result =
-            collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
-        if let Err(reason) = collect_result {
-            // Inactivate line and revert state
-            lines.set_active_status(line_no, Inactive(reason));
-            state = orig_state;
-            continue;
+        if lines.info(line_no).is_active() {
+            let collect_result =
+                collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
+            if let Err(reason) = collect_result {
+                // Inactivate line and revert state
+                lines.set_active_status(line_no, Inactive(reason));
+                state = orig_state;
+                continue;
+            }
         }
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -660,7 +660,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             let collect_result =
                 collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
             if let Err(reason) = collect_result {
-                lines.set_active_status(line_no, Inactive(reason.leak()));
+                lines.set_active_status(line_no, Inactive(reason));
                 continue;
             }
         }
@@ -798,7 +798,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             let collect_result =
                 collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
             if let Err(reason) = collect_result {
-                lines.set_active_status(line_no, Inactive(reason.leak()));
+                lines.set_active_status(line_no, Inactive(reason));
                 continue;
             }
         }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -670,8 +670,9 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     for line_no in 0..lines.len() {
         let line_kind = lines.info(line_no).kind.stripped_clone();
 
-        // Enforce correct symbolic reference consumption
+        // Handle symbolic reference (check consumption & collect local symbols)
         if lines.info(line_no).is_active() {
+            // Enforce correct symbolic reference consumption
             // end/else must match the label of the frame being closed, not any enclosing frame
             let label_symbol_defs: Vec<String> = match line_kind {
                 LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => frame_stack
@@ -692,6 +693,19 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             ) {
                 lines.set_active_status(line_no, Inactive("undefined symbolic reference"));
                 continue;
+            }
+
+            // Try to collect local symbols if the line "just in" the function header
+            if matches!(
+                state,
+                SyntaxState::Initial | SyntaxState::AfterFuncHeader(_)
+            ) {
+                let collect_result =
+                    collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
+                if let Err(reason) = collect_result {
+                    lines.set_active_status(line_no, Inactive(reason));
+                    continue;
+                }
             }
         }
 
@@ -729,6 +743,8 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
         }
 
         // Process the line and transition the syntax state
+        // Every invalidations for module parts should go before the state transition,
+        // since those line shouldn't trigger the state transition
         {
             let orig_state = state;
             let res = state.transit_state(&lines.info(line_no), |_| {});
@@ -790,16 +806,6 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                     },
                 ),
                 InstrKind::Other => (),
-            }
-        }
-
-        // Collect defined local symbolic references if there's any
-        if lines.info(line_no).is_active() {
-            let collect_result =
-                collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
-            if let Err(reason) = collect_result {
-                lines.set_active_status(line_no, Inactive(reason));
-                continue;
             }
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3046,6 +3046,25 @@ pub(crate) mod tests {
         }
 
         {
+            // issue #220
+            let mut editor = FakeTextBuffer::default();
+            editor.push_line("(memory $x 1)");
+            editor.push_line("(memory $x 2)");
+            editor.push_line("(global $x i32 (i32.const 0))");
+            editor.push_line("(global $x i64 (i32.const 0))");
+            editor.push_line("(func");
+            editor.push_line("(param $x i32) (param $x i32)");
+            editor.push_line("(param $x i32)");
+            editor.push_line("(local $x f32)");
+            editor.push_line(")");
+            editor.push_line("(func (param $x i32) (param $x i32)");
+            editor.push_line("(");
+            editor.push_line("func (param $x i32) (param $x i32)");
+            editor.push_line("func)");
+            test_editor_flow(&mut editor)?;
+        }
+
+        {
             let mut editor = FakeTextBuffer::default();
             editor.push_line("(func");
             editor.push_line("call $f");


### PR DESCRIPTION
This PR is for issue #220 
Change summary: 
- When collecting module-level or local symbolic references for a line, if encountering a duplicately defined symbolic reference, revert all collections for this line and return with error message.
- In fix_syntax, inactivate the line with err message displayed for duplicately defined symbolics.

Examples:
<img width="1920" height="947" alt="c7274499-ad66-4e68-a384-9d97a702107a" src="https://github.com/user-attachments/assets/347db1a2-f2f2-4ab1-8326-2783a87f85d4" />
