### PR TITLE
Instrumentation cleanups and ergonomic improvements

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -12,7 +12,8 @@
 use crate::utils::FmtError;
 use anyhow::{Context, Result, bail};
 use js_sys::{Object, Reflect, WebAssembly::RuntimeError};
-use std::cell::{Ref, RefCell};
+use regex::Regex;
+use std::cell::Cell;
 use thousands::{Separable, SeparatorPolicy};
 use wasm_bindgen::{JsCast, prelude::*};
 
@@ -20,8 +21,79 @@ const MAX_STEP_COUNT: usize = 1_000_000;
 
 // Debug state stored in Wasm memory
 thread_local! {
-    static STATE: RefCell<DebugState> = RefCell::new(DebugState::default());
+    static TERMINATION: Cell<TerminationType> = Cell::new(Default::default());
+    static ERROR_STR: CodillonCell<String> = CodillonCell::new(Default::default());
+    static STEP_COUNT: Cell<usize> = const { Cell::new(0) };
+    static STEPS: Box<[CodillonCell<ExecutionStep>]> = (0..MAX_STEP_COUNT)
+                .map(|_| CodillonCell::new(ExecutionStep::default()))
+                .collect();
     static INSTRUMENTATION_IMPORTS: Object = make_imports().expect("instrumentation");
+}
+
+// When a user Wasm module gets close to stack exhaustion, the browser can trap at any point
+// in our code (without unwinding the stack), leaving a RefCell borrow flag set.
+// Instead, we use our own RefCell approximation (still in safe Rust) that merely logs the issue.
+// The worst-case consequence of a trap in an inconvenient place would be that the current (in-progress)
+// step gets blanked to the default value.
+// This is all pretty gross, but it seems difficult to gracefully handle a trap in the middle of
+// "our" code (as called by the Wasm module).
+struct CodillonCell<T: Default> {
+    inner: Cell<T>,
+    #[cfg(debug_assertions)]
+    borrowed: Cell<bool>,
+}
+
+impl<T: Default> CodillonCell<T> {
+    fn new(inner: T) -> Self {
+        Self {
+            inner: Cell::new(inner),
+            #[cfg(debug_assertions)]
+            borrowed: Cell::new(false),
+        }
+    }
+
+    fn set(&self, inner: T) {
+        self.inner.set(inner)
+    }
+
+    fn borrow(&self) {
+        #[cfg(debug_assertions)]
+        {
+            if self.borrowed.get() {
+                web_sys::console::log_1(&"warning: CodillonCell multiply borrowed".into());
+            }
+            self.borrowed.set(true);
+        }
+    }
+
+    fn unborrow(&self) {
+        #[cfg(debug_assertions)]
+        self.borrowed.set(false);
+    }
+
+    fn with<U, F>(&self, func: F) -> U
+    where
+        F: FnOnce(&T) -> U,
+    {
+        self.borrow();
+        let cur = self.inner.take();
+        let ret = func(&cur);
+        self.set(cur);
+        self.unborrow();
+        ret
+    }
+
+    fn with_mut<U, F>(&self, func: F) -> U
+    where
+        F: FnOnce(&mut T) -> U,
+    {
+        self.borrow();
+        let mut cur = self.inner.take();
+        let ret = func(&mut cur);
+        self.set(cur);
+        self.unborrow();
+        ret
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -64,47 +136,84 @@ impl Separable for WasmValue {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, PartialEq)]
 pub enum TerminationType {
     #[default]
     Running,
     TooManySteps,
     HitInvalid,
     HitBadImport,
-    Error(String),
+    Error,
     Success,
 }
 
-#[derive(Default)]
-pub struct DebugState {
-    pub current_step: ExecutionStep,
-    pub completed_steps: Vec<ExecutionStep>,
-    pub termination: TerminationType,
+fn reset_debug_state() {
+    TERMINATION.set(Default::default());
+    ERROR_STR.with(|e| e.set(String::new()));
+    STEP_COUNT.set(0);
+    with_current_step_mut(|step| step.reset());
 }
 
-impl DebugState {
-    fn reset(&mut self) {
-        self.current_step = Default::default();
-        self.completed_steps.clear();
-        self.termination = Default::default();
+fn commit_step() {
+    assert!(STEP_COUNT.get() < MAX_STEP_COUNT);
+    STEP_COUNT.set(STEP_COUNT.get() + 1);
+    with_current_step_mut(|step| step.reset());
+}
+
+pub fn termination_type() -> TerminationType {
+    TERMINATION.get()
+}
+
+pub fn step_count() -> usize {
+    STEP_COUNT.get()
+}
+
+fn with_completed_step<T, F>(idx: usize, func: F) -> T
+where
+    F: FnOnce(&ExecutionStep) -> T,
+{
+    assert!(idx < MAX_STEP_COUNT);
+    assert!(idx < step_count());
+    STEPS.with(|step_cell| step_cell[idx].with(|step| func(step)))
+}
+
+fn with_current_step_mut<T, F>(func: F) -> T
+where
+    F: FnOnce(&mut ExecutionStep) -> T,
+{
+    STEPS.with(|step_cell| step_cell[step_count()].with_mut(|step| func(step)))
+}
+
+fn error_string() -> Option<String> {
+    if termination_type() == TerminationType::Error {
+        ERROR_STR.with(|e| e.with(|err| Some(err.clone())))
+    } else {
+        None
     }
 }
 
-#[derive(Default, Debug)]
-pub struct ExecutionStep {
-    pub line_num: u32,
-    pub slot_assignments: Vec<(u32, WasmValue)>, // slot idx, value
-                                                 // XXX todo: memory
-                                                 // XXX todo: canvas operations
-                                                 // XXX todo: clear any func/frame on entry
-                                                 // XXX todo: save any func on call/call_indirect, restore after
+#[derive(Default, Debug, Clone)]
+struct ExecutionStep {
+    line_num: u32,
+    slot_assignments: Vec<(u32, WasmValue)>, // slot idx, value
+                                             // XXX todo: memory
+                                             // XXX todo: canvas operations
+                                             // XXX todo: clear any func/frame on entry
+                                             // XXX todo: save any func on call/call_indirect, restore after
+}
+
+impl ExecutionStep {
+    fn reset(&mut self) {
+        self.line_num = 0;
+        self.slot_assignments.clear();
+    }
 }
 
 #[derive(Default, Debug)]
 pub struct ExecutionState {
     pub step: usize,
     pub slots: Vec<Option<WasmValue>>,
-    pub status: Option<(usize, TerminationType)>,
+    pub status: Option<(usize, TerminationType, Option<String>)>,
 }
 
 impl ExecutionState {
@@ -122,26 +231,27 @@ impl ExecutionState {
             // XXX save checkpoints?
             self.reset(self.slots.len());
         }
-        with_debug_state(|state| {
-            if state.completed_steps.is_empty() {
-                return;
-            }
-            assert!(target_step < state.completed_steps.len());
-            for step in 0..=target_step {
-                for (slot_idx, value) in &state.completed_steps[step].slot_assignments {
+        if step_count() == 0 {
+            return;
+        }
+        assert!(target_step < step_count());
+        for step in 0..=target_step {
+            with_completed_step(step, |s| {
+                for (slot_idx, value) in &s.slot_assignments {
                     self.slots[*slot_idx as usize] = Some(*value);
                 }
-            }
-            self.step = target_step;
-            self.status = Some((
-                state.completed_steps[target_step].line_num as usize,
-                if target_step + 1 == state.completed_steps.len() {
-                    state.termination.clone()
-                } else {
-                    TerminationType::Running
-                },
-            ));
-        });
+            });
+        }
+        self.step = target_step;
+        self.status = Some((
+            with_completed_step(target_step, |s| s.line_num as usize),
+            if target_step + 1 == step_count() {
+                termination_type()
+            } else {
+                TerminationType::Running
+            },
+            error_string(),
+        ));
     }
 }
 
@@ -153,17 +263,6 @@ where
     func.forget();
 }
 
-pub fn reset_debug_state() {
-    STATE.with(|cur_state| cur_state.borrow_mut().reset())
-}
-
-pub fn with_debug_state<T, F>(func: F) -> T
-where
-    F: FnOnce(Ref<'_, DebugState>) -> T,
-{
-    STATE.with(|state| func(state.borrow()))
-}
-
 // Constructs the instrumentation functions for import
 fn make_imports() -> Result<Object, JsValue> {
     let imports = Object::new();
@@ -172,46 +271,46 @@ fn make_imports() -> Result<Object, JsValue> {
     // Updating the debug state at every step. Returns whether execution should continue.
     let step_closure = Closure::wrap(Box::new(move |line_num: u32| -> bool {
         use TerminationType::*;
-        STATE.with_borrow_mut(|state| {
-            if state.termination == HitBadImport
-                && let Some(prev_step) = state.completed_steps.last()
-            {
-                state.current_step.line_num = prev_step.line_num;
-            } else {
-                state.current_step.line_num = line_num;
-            }
+        if termination_type() == HitBadImport && step_count() > 0 {
+            with_completed_step(step_count() - 1, |completed| {
+                with_current_step_mut(|current| {
+                    current.line_num = completed.line_num;
+                })
+            });
+        } else {
+            with_current_step_mut(|step| step.line_num = line_num);
+        }
 
-            state
-                .completed_steps
-                .push(std::mem::take(&mut state.current_step));
+        commit_step();
 
-            match state.termination {
-                Running => (),
-                TooManySteps => panic!("execution unexpectedly continued after TooManySteps"),
-                HitInvalid | HitBadImport => return false,
-                Error(_) => panic!("execution unexpectedly continued after Error"),
-                Success => panic!("execution unexpectedly continued after Success"),
-            }
+        match termination_type() {
+            Running => (),
+            TooManySteps => panic!("execution unexpectedly continued after TooManySteps"),
+            HitInvalid | HitBadImport => return false,
+            Error => panic!("execution unexpectedly continued after Error"),
+            Success => panic!("execution unexpectedly continued after Success"),
+        }
 
-            // Signal halt
-            if state.completed_steps.len() > MAX_STEP_COUNT {
-                state.termination = TerminationType::TooManySteps;
-                return false;
-            }
+        // Signal halt
+        if step_count() >= MAX_STEP_COUNT - 1 {
+            TERMINATION.set(TerminationType::TooManySteps);
+            return false;
+        }
 
-            true
-        })
+        true
     }) as Box<dyn Fn(u32) -> bool>);
     register_closure(&debug_numbers, "record_step", step_closure);
 
-    let record_invalid = Closure::wrap(Box::new(move || {
-        STATE.with_borrow_mut(|state| state.termination = TerminationType::HitInvalid)
-    }) as Box<dyn Fn()>);
+    let record_invalid =
+        Closure::wrap(
+            Box::new(move || TERMINATION.set(TerminationType::HitInvalid)) as Box<dyn Fn()>,
+        );
     register_closure(&debug_numbers, "record_invalid", record_invalid);
 
-    let func_placeholder = Closure::wrap(Box::new(move || {
-        STATE.with_borrow_mut(|state| state.termination = TerminationType::HitBadImport)
-    }) as Box<dyn Fn()>);
+    let func_placeholder =
+        Closure::wrap(
+            Box::new(move || TERMINATION.set(TerminationType::HitBadImport)) as Box<dyn Fn()>,
+        );
     register_closure(&debug_numbers, "func_placeholder", func_placeholder);
 
     create_closure_record_operations(&debug_numbers);
@@ -256,13 +355,7 @@ fn create_closure_helpers(import: &Object) {
 
 fn create_closure_record_operations(obj: &Object) {
     let record = |value: WasmValue, slot: u32| {
-        STATE.with(|state| {
-            state
-                .borrow_mut()
-                .current_step
-                .slot_assignments
-                .push((slot, value))
-        });
+        with_current_step_mut(|step| step.slot_assignments.push((slot, value)))
     };
     let record_i32 = Closure::wrap(
         Box::new(move |value: i32, slot: u32| record(value.into(), slot)) as Box<dyn Fn(i32, u32)>,
@@ -302,47 +395,55 @@ pub async fn run_binary(binary: &[u8]) -> Result<()> {
                 .context("main is not an exported function")?;
             match main.apply(&JsValue::null(), &js_sys::Array::new()) {
                 Ok(val) if val.is_undefined() => {
-                    STATE.with_borrow_mut(|state| match state.termination {
-                        TerminationType::Running => state.termination = TerminationType::Success,
+                    match termination_type() {
+                        TerminationType::Running => TERMINATION.set(TerminationType::Success),
                         TerminationType::TooManySteps
                         | TerminationType::HitInvalid
                         | TerminationType::HitBadImport
                         | TerminationType::Success
-                        | TerminationType::Error(..) => {
+                        | TerminationType::Error => {
                             unreachable!("success after other result");
                         }
-                    });
+                    }
                     Ok(())
                 }
                 Ok(val) => {
                     bail!("unhandled return value from function: {:?}", val)
                 }
-                Err(e) => match e.dyn_ref::<RuntimeError>() {
-                    Some(r) => {
-                        let reason: String = r.message().into();
-                        STATE.with_borrow_mut(|state| match state.termination {
-                            TerminationType::Running => {
-                                if let Some(step) = state.completed_steps.last() {
-                                    state.current_step.line_num = step.line_num;
-                                    state
-                                        .completed_steps
-                                        .push(std::mem::take(&mut state.current_step));
-                                }
-                                state.termination = TerminationType::Error(reason)
+                Err(e) => {
+                    let reason: String = if let Some(r) = e.dyn_ref::<RuntimeError>() {
+                        r.message().into()
+                    } else {
+                        let re = Regex::new(r"\((.*)")?;
+                        let debug_string = format!("{e:?}");
+                        if let Some(captures) = re.captures(&debug_string) {
+                            captures[1].to_string()
+                        } else {
+                            "unknown error".to_string()
+                        }
+                    };
+                    match termination_type() {
+                        TerminationType::Running => {
+                            if step_count() > 0 {
+                                with_completed_step(step_count() - 1, |completed| {
+                                    with_current_step_mut(|current| {
+                                        current.line_num = completed.line_num;
+                                    })
+                                });
                             }
-                            TerminationType::HitInvalid
-                            | TerminationType::HitBadImport
-                            | TerminationType::TooManySteps => {} // error is expected
-                            TerminationType::Success | TerminationType::Error(..) => {
-                                unreachable!("error after other result");
-                            }
-                        });
-                        Ok(())
+                            commit_step();
+                            TERMINATION.set(TerminationType::Error);
+                            ERROR_STR.with(|e| e.set(reason));
+                        }
+                        TerminationType::HitInvalid
+                        | TerminationType::HitBadImport
+                        | TerminationType::TooManySteps => {} // error is expected
+                        TerminationType::Success | TerminationType::Error => {
+                            unreachable!("error after other result");
+                        }
                     }
-                    None => {
-                        bail!("other failure: {:?}", e);
-                    }
-                },
+                    Ok(())
+                }
             }
         }
         Err(e) => bail!("reflection failure: {:?}", e),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -3,7 +3,7 @@
 use crate::{
     action_history::{ActionHistory, Edit, Selection},
     autocomplete::Autocomplete,
-    debug::{DebugState, ExecutionState, TerminationType, run_binary, with_debug_state},
+    debug::{ExecutionState, TerminationType, run_binary, step_count, termination_type},
     dom_canvas::DomCanvas,
     dom_struct::DomStruct,
     dom_vec::DomVec,
@@ -145,10 +145,7 @@ impl Editor {
             let editor_ref = Rc::clone(&ret.0);
             ret.slider_mut().set_oninput(move |_| {
                 let editor = Editor(editor_ref.clone());
-                let step_count = with_debug_state(|state| state.completed_steps.len());
-                with_debug_state(|state| {
-                    editor.update_live_info(step_count, editor.current_step(), &state);
-                });
+                editor.update_live_info(step_count(), editor.current_step());
             });
 
             let editor = Editor(Rc::clone(&ret.0));
@@ -712,14 +709,11 @@ impl Editor {
             self.execute(instrumented_binary, version);
             self.0.borrow_mut().previous_instrumented_binary_hash = instrumented_binary_hash;
         } else {
-            with_debug_state(|state| {
-                let step_count = state.completed_steps.len();
-                if step_count > 0 {
-                    self.update_live_info(step_count, self.current_step(), &state);
-                } else {
-                    self.image_mut().set_arrow_location(None);
-                }
-            });
+            if step_count() > 0 {
+                self.update_live_info(step_count(), self.current_step());
+            } else {
+                self.image_mut().set_arrow_location(None);
+            }
         }
 
         self.schedule_save(); // schedule save to local storage
@@ -990,29 +984,26 @@ impl Editor {
                     continue;
                 }
 
-                with_debug_state(|state| {
-                    let step_count = state.completed_steps.len();
-                    let mut slider_step = editor_handle.current_step();
-                    // Move slider to the end if binary changed and it's in the middle
-                    if step_count == 0 {
-                        editor_handle.slider_mut().inner_mut().hide();
-                        editor_handle.image_mut().set_arrow_location(None);
-                        return;
-                    }
+                let mut slider_step = editor_handle.current_step();
+                // Move slider to the end if binary changed and it's in the middle
+                if step_count() == 0 {
+                    editor_handle.slider_mut().inner_mut().hide();
+                    editor_handle.image_mut().set_arrow_location(None);
+                    return;
+                }
 
-                    if editor_handle.slider().inner().is_visible() {
-                        if slider_step != 0 {
-                            slider_step = step_count - 1;
-                        }
-                    } else {
-                        slider_step = step_count - 1;
+                if editor_handle.slider().inner().is_visible() {
+                    if slider_step != 0 {
+                        slider_step = step_count() - 1;
                     }
+                } else {
+                    slider_step = step_count() - 1;
+                }
 
-                    let slot_count = editor_handle.slot_connections().written.len();
-                    editor_handle.execution_state_mut().reset(slot_count);
-                    editor_handle.update_live_info(step_count, slider_step, &state);
-                    editor_handle.move_slider(slider_step);
-                });
+                let slot_count = editor_handle.slot_connections().written.len();
+                editor_handle.execution_state_mut().reset(slot_count);
+                editor_handle.update_live_info(step_count(), slider_step);
+                editor_handle.move_slider(slider_step);
             }
             inner.borrow_mut().worker_running = false;
         });
@@ -1035,23 +1026,23 @@ impl Editor {
             .set_value_as_number(current_step as f64);
     }
 
-    fn update_live_info(&self, step_count: usize, current_step: usize, debug_state: &DebugState) {
+    fn update_live_info(&self, step_count: usize, current_step: usize) {
         assert!(step_count > 0);
         if step_count > 1 {
             self.slider_mut().inner_mut().show();
             self.slider_mut().inner_mut().build_ticks(
                 step_count - 1,
                 current_step,
-                &debug_state.termination,
-            );
+                &termination_type(),
+            )
         } else {
             self.slider_mut().inner_mut().hide();
         }
 
         fn find_error(state: &ExecutionState) -> Option<(usize, &str)> {
             Some(match &state.status {
-                Some((line_no, TerminationType::Error(msg))) => (*line_no, msg),
-                Some((line_no, TerminationType::HitBadImport)) => {
+                Some((line_no, TerminationType::Error, Some(msg))) => (*line_no, msg),
+                Some((line_no, TerminationType::HitBadImport, _)) => {
                     (*line_no, "called unknown import")
                 }
                 _ => return None,
@@ -1078,7 +1069,7 @@ impl Editor {
         editor_ref.execution_state.goto_step(current_step);
         Self::update_slots(editor_ref);
         if step_count > 1
-            && let Some((line_no, _)) = &editor_ref.execution_state.status
+            && let Some((line_no, _, _)) = &editor_ref.execution_state.status
             && let Some(indent) = &editor_ref.component.get().1.1.0.inner()[*line_no]
                 .info()
                 .indent

--- a/src/slider.rs
+++ b/src/slider.rs
@@ -74,8 +74,8 @@ impl Slider {
         // use 1x, 2x, or 5x multiples of 10 for intervals
         match quarter {
             0 => interval,
-            1 => interval * 2,
-            2 => interval * 5,
+            //            1 => interval * 2,
+            1 | 2 => interval * 5,
             _ => interval * 10,
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1267,6 +1267,8 @@ impl<'a> ValidModule<'a> {
             primitive_record(&mut new_function, local)?;
         }
 
+        step_debug(&mut new_function, orig_function.lines.0);
+
         // Record all operators, translating func idxes as necessary
         for (i, codillon_operator) in orig_function.operators.iter().enumerate() {
             step_debug(&mut new_function, codillon_operator.line_idx);
@@ -1299,12 +1301,24 @@ impl<'a> ValidModule<'a> {
                 }
             }
 
+            if i + 1 == orig_function.operators.len() {
+                debug_assert!(matches!(op, End));
+                debug_assert!(codillon_operator.inner.info == OpInfo::FuncEnd);
+
+                // special handling for the function end (we can't put instrumentation after it,
+                // but we know the type of end operator is identity on its inputs)
+                transparent_record_results(&mut new_function, &op_type.outputs);
+
+                new_function.instruction(&op);
+                continue; // function is over
+            }
+
             // the operator itself
             new_function.instruction(&op);
 
-            if i + 1 == orig_function.operators.len() {
-                debug_assert!(matches!(op, End));
-                continue; // function is over
+            if matches!(op, Call(_) | CallIndirect { .. }) {
+                // special handling: step this twice so pointer can return to the callsite after complete
+                step_debug(&mut new_function, codillon_operator.line_idx);
             }
 
             // record result operands
@@ -2458,6 +2472,8 @@ pub(crate) mod tests {
                 + r#"  (func (type 0)
     i32.const 0
     call 7
+    i32.const 0
+    call 7
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2473,6 +2489,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
   )
@@ -2492,6 +2510,8 @@ pub(crate) mod tests {
                 + r#"  (func (type 0)
     i32.const 1
     call 7
+    i32.const 1
+    call 7
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2507,6 +2527,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
   )
@@ -2526,6 +2548,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 0
     call 7
     i64.const 17
@@ -2550,7 +2574,9 @@ pub(crate) mod tests {
         }
 
         // well-formed block
-        const JUST_BLOCK_END: &str = r#"    i32.const 1
+        const JUST_BLOCK_END: &str = r#"    i32.const 0
+    call 7
+    i32.const 1
     call 7
     block ;; label = @1
       i32.const 2
@@ -2609,6 +2635,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
     i32.const 137
@@ -2659,6 +2687,8 @@ pub(crate) mod tests {
   (func (type 0)
     i32.const 6
     call 8
+    i32.const 6
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2702,6 +2732,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
     block ;; label = @1
@@ -2733,6 +2765,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
     i32.const 1
@@ -2761,6 +2795,8 @@ pub(crate) mod tests {
                 + "  (memory 0)\n"
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 1
+    call 7
     i32.const 2
     call 7
     i32.const 2
@@ -2794,6 +2830,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 0
     call 7
     loop ;; label = @1
@@ -2836,6 +2874,8 @@ pub(crate) mod tests {
                 + EXPECTED_IMPORTS
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
     i32.const 4
@@ -2891,9 +2931,13 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f64" (func (type 8)))
   (export "main" (func 6))
   (func (type 0)
+    i32.const 0
+    call 8
     i32.const 1
     call 8
     call 7
+    i32.const 1
+    call 8
     i32.const 0
     i32.const 1
     call 9
@@ -2909,6 +2953,8 @@ pub(crate) mod tests {
     unreachable
   )
   (func (type 1) (result i32 i32)
+    i32.const 4
+    call 8
     i32.const 5
     call 8
     i32.const 9
@@ -2921,6 +2967,9 @@ pub(crate) mod tests {
     call 10
     i32.const 7
     call 8
+    i32.const 5
+    i32.const 6
+    call 9
   )
   (func (type 9) (param i32)
     local.get 0
@@ -2977,6 +3026,8 @@ pub(crate) mod tests {
     local.get 3
     i32.const 3
     call 5
+    i32.const 0
+    call 7
     i32.const 4
     call 7
   )
@@ -3013,6 +3064,8 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f64" (func (type 8)))
   (export "main" (func 6))
   (func (type 0)
+    i32.const 0
+    call 7
     i32.const 1
     call 7
     i32.const 1
@@ -3062,9 +3115,13 @@ pub(crate) mod tests {
                 + r#"  (import "codillon_debug" "func_placeholder" (func (type 1)))
   (export "main" (func 7))
   (func (type 0)
+    i32.const 1
+    call 8
     i32.const 2
     call 8
     call 6
+    i32.const 2
+    call 8
     i32.const 3
     call 8
   )


### PR DESCRIPTION
1. Collect outputs of the function "end" operator
2. For call/call_indirect, show a step that returns back to the callsite before continuing
3. Record an empty "step" at the beginning of each function
4. Handle stack exhaustion (infinite recursion) without crashing

Closes: #225 