### PR TITLE
syntax: don't register module-level symbolic identifiers from lines that will be deactivated

### DIFF
--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -14,7 +14,7 @@ use wast::{
 use crate::syntax::{LineKind, ModulePart};
 
 #[derive(Clone, Debug, PartialEq)]
-enum IndexSpace {
+pub enum IndexSpace {
     Type,
     Global,
     Mem,
@@ -88,6 +88,12 @@ impl ModuleIdentifiers {
             IndexSpace::Data => Some(&mut self.datas),
             IndexSpace::Elem => Some(&mut self.elems),
             _ => None,
+        }
+    }
+
+    pub fn remove(&mut self, space: &IndexSpace, name: &str) {
+        if let Some(set) = self.set_mut(space) {
+            set.remove(name);
         }
     }
 }

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -13,8 +13,8 @@ use wast::{
 
 use crate::syntax::{LineKind, ModulePart};
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub enum IndexSpace {
+#[derive(Clone, Debug, PartialEq)]
+enum IndexSpace {
     Type,
     Global,
     Mem,
@@ -90,22 +90,12 @@ impl ModuleIdentifiers {
             _ => None,
         }
     }
-
-    pub fn contains(&self, space: &IndexSpace, name: &str) -> bool {
-        self.set(space).is_some_and(|s| s.contains(name))
-    }
-
-    pub fn remove(&mut self, space: &IndexSpace, name: &str) {
-        if let Some(set) = self.set_mut(space) {
-            set.remove(name);
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
 pub struct SymbolRef {
-    pub name: String,
-    pub space: IndexSpace,
+    name: String,
+    space: IndexSpace,
 }
 
 impl SymbolRef {
@@ -119,8 +109,8 @@ impl SymbolRef {
 
 #[derive(Default, Debug, Clone)]
 pub struct LineSymbols {
-    pub defines: Vec<SymbolRef>,
-    pub consumes: Vec<SymbolRef>,
+    defines: Vec<SymbolRef>,
+    consumes: Vec<SymbolRef>,
 }
 
 impl LineSymbols {
@@ -131,36 +121,38 @@ impl LineSymbols {
 }
 
 // Collect module-level defined symbols; no action for non-module-level symbols.
-// Returns the inserted symbols on success, or an error (with collection reverted) on duplicate.
+// Returns an error and revert the collection if any line symbol is a duplicate within
+// its index space.
 pub fn collect_module_symbols(
     line_symbols: &LineSymbols,
     identifiers: &mut ModuleIdentifiers,
-) -> Result<Vec<(IndexSpace, String)>, &'static str> {
-    let mut inserted: Vec<(IndexSpace, String)> = Vec::new();
+) -> Result<(), &'static str> {
+    let mut inserted: Vec<(&IndexSpace, &str)> = Vec::new();
 
     for symbol in &line_symbols.defines {
         if let Some(set) = identifiers.set_mut(&symbol.space) {
             if !set.insert(symbol.name.clone()) {
                 // Revert collections and return with err
-                for (space, name) in &inserted {
-                    identifiers.set_mut(space).unwrap().remove(name.as_str());
+                for (space, name) in inserted {
+                    identifiers.set_mut(space).unwrap().remove(name);
                 }
                 return Err("duplicate symbolic reference in same index space");
             }
-            inserted.push((symbol.space.clone(), symbol.name.clone()));
+            inserted.push((&symbol.space, &symbol.name));
         }
     }
 
-    Ok(inserted)
+    Ok(())
 }
 
 // Collect function-scoped defined Local symbols; no action for non-local symbols.
-// Returns the inserted symbols on success, or an error (with collection reverted) on duplicate.
+// Returns an error and revert the collection if any line symbol is a duplicate within
+// that function scope.
 pub fn collect_local_symbols(
     line_symbols: &LineSymbols,
     locals: &mut HashSet<String>,
-) -> Result<Vec<String>, &'static str> {
-    let mut inserted: Vec<String> = Vec::new();
+) -> Result<(), &'static str> {
+    let mut inserted: Vec<&str> = Vec::new();
 
     for symbol in &line_symbols.defines {
         if symbol.space != IndexSpace::Local {
@@ -168,15 +160,15 @@ pub fn collect_local_symbols(
         }
         if !locals.insert(symbol.name.clone()) {
             // Revert collections and return with err
-            for name in &inserted {
-                locals.remove(name.as_str());
+            for name in inserted {
+                locals.remove(name);
             }
             return Err("duplicate local symbolic reference");
         }
-        inserted.push(symbol.name.clone());
+        inserted.push(&symbol.name);
     }
 
-    Ok(inserted)
+    Ok(())
 }
 
 // Return the label defined in the line, if there's any, ignoring non-label symbols.

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -13,7 +13,7 @@ use wast::{
 
 use crate::syntax::{LineKind, ModulePart};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum IndexSpace {
     Type,
     Global,
@@ -91,6 +91,10 @@ impl ModuleIdentifiers {
         }
     }
 
+    pub fn contains(&self, space: &IndexSpace, name: &str) -> bool {
+        self.set(space).is_some_and(|s| s.contains(name))
+    }
+
     pub fn remove(&mut self, space: &IndexSpace, name: &str) {
         if let Some(set) = self.set_mut(space) {
             set.remove(name);
@@ -100,8 +104,8 @@ impl ModuleIdentifiers {
 
 #[derive(Clone, Debug)]
 pub struct SymbolRef {
-    name: String,
-    space: IndexSpace,
+    pub name: String,
+    pub space: IndexSpace,
 }
 
 impl SymbolRef {
@@ -115,8 +119,8 @@ impl SymbolRef {
 
 #[derive(Default, Debug, Clone)]
 pub struct LineSymbols {
-    defines: Vec<SymbolRef>,
-    consumes: Vec<SymbolRef>,
+    pub defines: Vec<SymbolRef>,
+    pub consumes: Vec<SymbolRef>,
 }
 
 impl LineSymbols {

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -127,38 +127,36 @@ impl LineSymbols {
 }
 
 // Collect module-level defined symbols; no action for non-module-level symbols.
-// Returns an error and revert the collection if any line symbol is a duplicate within
-// its index space.
+// Returns the inserted symbols on success, or an error (with collection reverted) on duplicate.
 pub fn collect_module_symbols(
     line_symbols: &LineSymbols,
     identifiers: &mut ModuleIdentifiers,
-) -> Result<(), &'static str> {
-    let mut inserted: Vec<(&IndexSpace, &str)> = Vec::new();
+) -> Result<Vec<(IndexSpace, String)>, &'static str> {
+    let mut inserted: Vec<(IndexSpace, String)> = Vec::new();
 
     for symbol in &line_symbols.defines {
         if let Some(set) = identifiers.set_mut(&symbol.space) {
             if !set.insert(symbol.name.clone()) {
                 // Revert collections and return with err
-                for (space, name) in inserted {
-                    identifiers.set_mut(space).unwrap().remove(name);
+                for (space, name) in &inserted {
+                    identifiers.set_mut(space).unwrap().remove(name.as_str());
                 }
                 return Err("duplicate symbolic reference in same index space");
             }
-            inserted.push((&symbol.space, &symbol.name));
+            inserted.push((symbol.space.clone(), symbol.name.clone()));
         }
     }
 
-    Ok(())
+    Ok(inserted)
 }
 
 // Collect function-scoped defined Local symbols; no action for non-local symbols.
-// Returns an error and revert the collection if any line symbol is a duplicate within
-// that function scope.
+// Returns the inserted symbols on success, or an error (with collection reverted) on duplicate.
 pub fn collect_local_symbols(
     line_symbols: &LineSymbols,
     locals: &mut HashSet<String>,
-) -> Result<(), &'static str> {
-    let mut inserted: Vec<&str> = Vec::new();
+) -> Result<Vec<String>, &'static str> {
+    let mut inserted: Vec<String> = Vec::new();
 
     for symbol in &line_symbols.defines {
         if symbol.space != IndexSpace::Local {
@@ -166,15 +164,15 @@ pub fn collect_local_symbols(
         }
         if !locals.insert(symbol.name.clone()) {
             // Revert collections and return with err
-            for name in inserted {
-                locals.remove(name);
+            for name in &inserted {
+                locals.remove(name.as_str());
             }
             return Err("duplicate local symbolic reference");
         }
-        inserted.push(&symbol.name);
+        inserted.push(symbol.name.clone());
     }
 
-    Ok(())
+    Ok(inserted)
 }
 
 // Return the label defined in the line, if there's any, ignoring non-label symbols.

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,8 +2,8 @@
 
 use crate::line::LineInfo;
 use crate::symbolic::{
-    IndexSpace, ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
-    symbols_resolved,
+    IndexSpace, ModuleIdentifiers, collect_label_symbol, collect_local_symbols,
+    collect_module_symbols, symbols_resolved,
 };
 use anyhow::Result;
 use std::collections::HashSet;
@@ -611,10 +611,11 @@ impl SyntaxState {
 // LineMutations stores the changes for a line in fix_syntax, enabling rollback.
 // In fix_syntax, global changes, including
 // - state transition
+// - before_imports state
 // - symbolic reference collection
 // - frame_stack operations,
 // need to be reverted if the line is eventually inactivated.
-// Note: Line changes such as setting synthetic_before doesn't strictly need to be 
+// Note: Line changes such as setting synthetic_before doesn't strictly need to be
 //       reverted because they won't take effect for inactive lines.
 enum FrameChange {
     None,
@@ -625,6 +626,7 @@ enum FrameChange {
 
 struct LineMutations {
     old_state: SyntaxState,
+    old_before_imports: bool,
     module_symbols: Vec<(IndexSpace, String)>,
     local_symbols: Vec<String>,
     frame_change: FrameChange,
@@ -635,25 +637,22 @@ impl LineMutations {
     // This function should be called when the line is inactivated.
     fn revert(
         self,
-        line_no: usize,
-        lines: &mut impl LineInfosMut,
         state: &mut SyntaxState,
+        before_imports: &mut bool,
         frame_stack: &mut Vec<(InstrKind, Option<String>)>,
         local_symbol_defs: &mut HashSet<String>,
         module_symbol_defs: &mut ModuleIdentifiers,
     ) {
-        // Revert SyntaxState
         *state = self.old_state;
+        *before_imports = self.old_before_imports;
 
-        // Revert symbol collections
-        for (space, name) in self.module_symbols { 
+        for (space, name) in self.module_symbols {
             module_symbol_defs.remove(&space, &name);
         }
-        for sym in self.local_symbols { 
+        for sym in self.local_symbols {
             local_symbol_defs.remove(&sym);
         }
 
-        // Revert frame stack
         match self.frame_change {
             FrameChange::None => {}
             FrameChange::Pushed(_, _) => { frame_stack.pop(); }
@@ -664,6 +663,161 @@ impl LineMutations {
             }
         }
     }
+}
+
+// Attempt all syntax fixes for a single line, mutating global processing state.
+// Accumulate changes into mutations as it proceeds.
+// Return Err if the line should be inactivated; the caller is responsible for
+// calling mutations.revert() to undo any partial changes.
+fn try_fix_syntax(
+    line_no: usize,
+    lines: &mut impl LineInfosMut,
+    state: &mut SyntaxState,
+    frame_stack: &mut Vec<(InstrKind, Option<String>)>,
+    local_symbol_defs: &mut HashSet<String>,
+    module_symbol_defs: &mut ModuleIdentifiers,
+    before_imports: &mut bool,
+    mutations: &mut LineMutations,
+) -> Result<(), &'static str> {
+    use crate::line::Activity::*;
+    use SyntaxState::*;
+
+    mutations.old_state = *state;
+    mutations.old_before_imports = *before_imports;
+    mutations.module_symbols.clear();
+    mutations.local_symbols.clear();
+    mutations.frame_change = FrameChange::None;
+
+    let line_kind = lines.info(line_no).kind.stripped_clone();
+
+    // Enforce no imports after other module fields, and collect module-level symbols
+    if let LineKind::Other(parts) = &line_kind {
+        let has_import = parts
+            .iter()
+            .any(|&p| matches!(p, ModulePart::Import | ModulePart::InlineImport));
+        let module_field = parts.iter().any(|&p| {
+            matches!(
+                p,
+                ModulePart::Memory
+                    | ModulePart::Table
+                    | ModulePart::Global
+                    | ModulePart::Export
+            )
+        });
+
+        if has_import && !*before_imports {
+            return Err("imports must appear before other module fields");
+        } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
+            *before_imports = false;
+        }
+
+        let added = collect_module_symbols(&lines.info(line_no).symbols, module_symbol_defs)?;
+        mutations.module_symbols.extend(added);
+    }
+
+    // Enforce correct symbolic reference consumption
+    let label_symbol_defs: Vec<String> = match &line_kind {
+        LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => frame_stack
+            .last()
+            .and_then(|(_, label)| label.clone())
+            .into_iter()
+            .collect(),
+        _ => frame_stack
+            .iter()
+            .filter_map(|(_, label)| label.clone())
+            .collect(),
+    };
+    if !symbols_resolved(
+        &lines.info(line_no).symbols,
+        module_symbol_defs,
+        local_symbol_defs,
+        &label_symbol_defs,
+    ) {
+        return Err("undefined symbolic reference");
+    }
+
+    // Fixup instructions that appear where they don't belong
+    if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
+        match state {
+            // Fix #1: Disable an instruction that appears in an imported function
+            AfterFuncHeader(FuncHeader { is_import: true, .. }) => {
+                return Err("imported functions cannot have instructions");
+            }
+            // Fix #2: prepend "(func" if an instruction appears at module scope
+            Initial => lines.set_synthetic_before(
+                line_no,
+                SyntheticWasm {
+                    module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
+                    ..Default::default()
+                },
+            ),
+            // Fix #3: prepend "func" if an instruction appears after just "("
+            AfterModuleFieldLParen => lines.set_synthetic_before(
+                line_no,
+                SyntheticWasm {
+                    module_field_syntax: vec![ModulePart::FuncKeyword],
+                    ..Default::default()
+                },
+            ),
+            _ => {}
+        }
+    }
+
+    // Process the line and transition the syntax state
+    state.transit_state(&lines.info(line_no), |_| {})?;
+
+    if *state == Initial {
+        // Fix #4: at end of function body, synthetically close all open frames
+        lines.set_synthetic_before(
+            line_no,
+            SyntheticWasm {
+                end_opcodes: frame_stack.len(),
+                ..Default::default()
+            },
+        );
+        frame_stack.clear();
+        local_symbol_defs.clear();
+        return Ok(());
+    }
+
+    // Enforce syntax requirements of structured instructions
+    if let LineKind::Instr(instr_kind) = line_kind {
+        match instr_kind {
+            // For a structured instruction that opens a frame, log this.
+            InstrKind::If | InstrKind::Loop | InstrKind::OtherStructured => {
+                let label = collect_label_symbol(&lines.info(line_no).symbols);
+                frame_stack.push((instr_kind, label.clone()));
+                mutations.frame_change = FrameChange::Pushed(instr_kind, label);
+            }
+
+            // Fix #5: if an `else` appears outside an `if` frame, disable it
+            InstrKind::Else => {
+                if let Some((InstrKind::If, _)) = frame_stack.last() {
+                    let (_, if_label) = frame_stack.pop().unwrap();
+                    frame_stack.push((InstrKind::Else, if_label.clone()));
+                    mutations.frame_change = FrameChange::ReplacedIfWithElse(if_label);
+                } else {
+                    return Err("'else' outside 'if'");
+                }
+            }
+
+            // Fix #6: if an `end` appears outside a frame, disable it
+            InstrKind::End => {
+                if let Some(popped) = frame_stack.pop() {
+                    mutations.frame_change = FrameChange::Popped(popped.0, popped.1);
+                } else {
+                    return Err("nothing to end");
+                }
+            }
+            InstrKind::Other => {}
+        }
+    }
+
+    // Collect defined local symbolic references
+    let added = collect_local_symbols(&lines.info(line_no).symbols, local_symbol_defs)?;
+    mutations.local_symbols.extend(added);
+
+    Ok(())
 }
 
 /// Fix frames (and missing function beginning and end) by deactivating,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,11 +2,11 @@
 
 use crate::line::LineInfo;
 use crate::symbolic::{
-    IndexSpace, ModuleIdentifiers, collect_label_symbol, collect_local_symbols,
-    collect_module_symbols, symbols_resolved,
+    ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
+    symbols_resolved,
 };
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::ops::Deref;
 use wast::{
     Error,
@@ -608,235 +608,7 @@ impl SyntaxState {
     }
 }
 
-// LineMutations stores the changes for a line in fix_syntax, enabling rollback.
-// In fix_syntax, global changes, including
-// - state transition
-// - before_imports state
-// - symbolic reference collection
-// - frame_stack operations,
-// need to be reverted if the line is eventually inactivated.
-// Note: Line changes such as setting synthetic_before doesn't strictly need to be
-//       reverted because they won't take effect for inactive lines.
-enum FrameChange {
-    None,
-    Pushed,
-    Popped(InstrKind, Option<String>),
-    ReplacedIfWithElse(Option<String>),
-}
-
-struct LineMutations {
-    old_state: SyntaxState,
-    old_before_imports: bool,
-    module_symbols: Vec<(IndexSpace, String)>,
-    local_symbols: Vec<String>,
-    frame_change: FrameChange, // frame_stack changes
-    clear_func: bool,          // clear func-scope states?
-}
-
-struct SyntaxFixContext<'a> {
-    state: &'a mut SyntaxState,
-    before_imports: &'a mut bool,
-    local_symbol_defs: &'a mut HashSet<String>,
-    module_symbol_defs: &'a mut ModuleIdentifiers,
-    frame_stack: &'a mut Vec<(InstrKind, Option<String>)>,
-}
-
-impl LineMutations {
-    fn new() -> Self {
-        Self {
-            old_state: SyntaxState::Initial,
-            old_before_imports: false,
-            module_symbols: Vec::new(),
-            local_symbols: Vec::new(),
-            frame_change: FrameChange::None,
-            clear_func: false,
-        }
-    }
-
-    fn revert(&self, ctx: &mut SyntaxFixContext<'_>) {
-        *ctx.state = self.old_state;
-        *ctx.before_imports = self.old_before_imports;
-
-        for (space, name) in &self.module_symbols {
-            ctx.module_symbol_defs.remove(space, name);
-        }
-        for sym in &self.local_symbols {
-            ctx.local_symbol_defs.remove(sym);
-        }
-
-        match &self.frame_change {
-            FrameChange::None => {}
-            FrameChange::Pushed => {
-                ctx.frame_stack.pop();
-            }
-            FrameChange::Popped(kind, label) => ctx.frame_stack.push((*kind, label.clone())),
-            FrameChange::ReplacedIfWithElse(label) => {
-                ctx.frame_stack.pop();
-                ctx.frame_stack.push((InstrKind::If, label.clone()));
-            }
-        }
-    }
-}
-
-// Attempt all syntax fixes for a single line, mutating global processing state.
-// Accumulate changes into mutations as it proceeds.
-// Return Err if the line should be inactivated; the caller is responsible for
-// calling mutations.revert() to undo any partial changes.
-fn try_fix_line_syntax(
-    line_no: usize,
-    lines: &mut impl LineInfosMut,
-    ctx: &mut SyntaxFixContext<'_>,
-    mutations: &mut LineMutations,
-) -> Result<(), &'static str> {
-    use SyntaxState::*;
-
-    let line_kind = lines.info(line_no).kind.stripped_clone();
-
-    // Enforce no imports after other module fields
-    if let LineKind::Other(parts) = &line_kind {
-        let has_import = parts
-            .iter()
-            .any(|&p| matches!(p, ModulePart::Import | ModulePart::InlineImport));
-        let module_field = parts.iter().any(|&p| {
-            matches!(
-                p,
-                ModulePart::Memory | ModulePart::Table | ModulePart::Global | ModulePart::Export
-            )
-        });
-
-        if has_import && !*ctx.before_imports {
-            return Err("imports must appear before other module fields");
-        } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
-            *ctx.before_imports = false;
-        }
-    }
-
-    // Enforce correct symbolic reference consumption
-    let label_symbol_defs: Vec<String> = match &line_kind {
-        LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => ctx
-            .frame_stack
-            .last()
-            .and_then(|(_, label)| label.clone())
-            .into_iter()
-            .collect(),
-        _ => ctx
-            .frame_stack
-            .iter()
-            .filter_map(|(_, label)| label.clone())
-            .collect(),
-    };
-    if !symbols_resolved(
-        &lines.info(line_no).symbols,
-        ctx.module_symbol_defs,
-        ctx.local_symbol_defs,
-        &label_symbol_defs,
-    ) {
-        return Err("undefined symbolic reference");
-    }
-
-    // Fixup instructions that appear where they don't belong
-    if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
-        match ctx.state {
-            // Fix #1: Disable an instruction that appears in an imported function
-            AfterFuncHeader(FuncHeader {
-                is_import: true, ..
-            }) => {
-                return Err("imported functions cannot have instructions");
-            }
-            // Fix #2: prepend "(func" if an instruction appears at module scope
-            Initial => {
-                lines.set_synthetic_before(
-                    line_no,
-                    SyntheticWasm {
-                        module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
-                        ..Default::default()
-                    },
-                );
-                // Synthetic ends take effect even if the line is inactivated
-                // old_state should reflect the states *after* synthetic ends
-                mutations.old_state = AfterFuncHeader(FuncHeader {
-                    is_import: false,
-                    next_field: 1,
-                });
-            }
-            // Fix #3: prepend "func" if an instruction appears after just "("
-            AfterModuleFieldLParen => {
-                lines.set_synthetic_before(
-                    line_no,
-                    SyntheticWasm {
-                        module_field_syntax: vec![ModulePart::FuncKeyword],
-                        ..Default::default()
-                    },
-                );
-                // Subsequent passes process this synthetic even for inactive lines.
-                mutations.old_state = AfterFuncHeader(FuncHeader {
-                    is_import: false,
-                    next_field: 1,
-                });
-            }
-            _ => {}
-        }
-    }
-
-    // Process the line and transition the syntax state
-    ctx.state.transit_state(&lines.info(line_no), |_| {})?;
-
-    if *ctx.state == Initial {
-        // Fix #4: at end of function body, synthetically close all open frames
-        lines.set_synthetic_before(
-            line_no,
-            SyntheticWasm {
-                end_opcodes: ctx.frame_stack.len(),
-                ..Default::default()
-            },
-        );
-        mutations.clear_func = true;
-        // old_state should reflect the states *after* synthetic ends
-        mutations.old_state = Initial;
-    }
-
-    // Enforce syntax requirements of structured instructions
-    if let LineKind::Instr(instr_kind) = line_kind {
-        match instr_kind {
-            // For a structured instruction that opens a frame, log this.
-            InstrKind::If | InstrKind::Loop | InstrKind::OtherStructured => {
-                let label = collect_label_symbol(&lines.info(line_no).symbols);
-                ctx.frame_stack.push((instr_kind, label.clone()));
-                mutations.frame_change = FrameChange::Pushed;
-            }
-
-            // Fix #5: if an `else` appears outside an `if` frame, disable it
-            InstrKind::Else => {
-                if let Some((InstrKind::If, _)) = ctx.frame_stack.last() {
-                    // Carry over labels from If frame
-                    let (_, if_label) = ctx.frame_stack.pop().unwrap();
-                    ctx.frame_stack.push((InstrKind::Else, if_label.clone()));
-                    mutations.frame_change = FrameChange::ReplacedIfWithElse(if_label);
-                } else {
-                    return Err("'else' outside 'if'");
-                }
-            }
-
-            // Fix #6: if an `end` appears outside a frame, disable it
-            InstrKind::End => {
-                if let Some(popped) = ctx.frame_stack.pop() {
-                    mutations.frame_change = FrameChange::Popped(popped.0, popped.1);
-                } else {
-                    return Err("nothing to end");
-                }
-            }
-            InstrKind::Other => {}
-        }
-    }
-
-    // Collect defined local symbolic references
-    let added = collect_local_symbols(&lines.info(line_no).symbols, ctx.local_symbol_defs)?;
-    mutations.local_symbols.extend(added);
-
-    Ok(())
-}
-
-/// Fix frames (and missing function beginning and end) by deactivating,
+/// Fix frames (and missing function beginning and end) by deactivating
 /// unmatched ends, appending ends as necessary to close open
 /// frames, prepending "(" and "func" and appending ")" as necessary, etc.
 pub fn fix_syntax(lines: &mut impl LineInfosMut) {
@@ -852,108 +624,205 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     let mut module_symbol_defs = ModuleIdentifiers::default();
     let mut local_symbol_defs: HashSet<String> = HashSet::new();
 
-    // Map a module-level symbol to its users' line numbers
-    // When a *forward* module-level symbol's def line is inactivated, the backward
-    // users' lines need to be inactivated also due to undefined symbolic reference
-    let mut module_symbol_users: HashMap<(IndexSpace, String), Vec<usize>> = HashMap::new();
-
     assert!(lines.len() > 0);
 
-    // "Global" changes from each line
-    let mut lines_mutations: Vec<LineMutations> =
-        (0..lines.len()).map(|_| LineMutations::new()).collect();
+    // first pass: disable imports appearing after other module fields,
+    // and declare module-scope symbolic ids for any surviving lines.
 
-    // Pre-scan: settle "global" states that must be known before per-line fixes, including
-    // - initialize per-line info;
-    // - collect all module-level symbols for forward reference resolution.
-    for (line_no, mutations) in (0..).zip(lines_mutations.iter_mut()) {
-        // Initialize per-line info
+    // There are probably still cases that can produce a "bounce."
+    for line_no in 0..lines.len() {
         lines.set_synthetic_before(line_no, SyntheticWasm::default());
         lines.set_active_status(line_no, Active);
         lines.set_invalid(line_no, None);
         lines.set_runtime_error(line_no, None);
 
-        // Collect module-level symbols
-        let collect_result =
-            collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
-        match collect_result {
-            Ok(added) => {
-                // Add the symbol collection to LineMutations. If the line is inactivated later,
-                // the inserted symbols will be removed.
-                mutations.module_symbols.extend(added);
-            }
-            Err(reason) => {
-                // Symbols are not collected. There's no global change so reversion is not needed,
-                // Inactivate the line directly,
-                lines.set_active_status(line_no, Inactive(reason));
+        let line_kind = lines.info(line_no).kind.stripped_clone();
+
+        // Enforce no imports after other module fields
+        if let LineKind::Other(parts) = &line_kind {
+            let has_import = parts
+                .iter()
+                .any(|&p| matches!(p, ModulePart::Import | ModulePart::InlineImport));
+            let module_field = parts.iter().any(|&p| {
+                matches!(
+                    p,
+                    ModulePart::Memory
+                        | ModulePart::Table
+                        | ModulePart::Global
+                        | ModulePart::Export
+                )
+            });
+            if has_import && !before_imports {
+                lines.set_active_status(
+                    line_no,
+                    Inactive("imports must appear before other module fields"),
+                );
+                continue;
+            } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
+                before_imports = false;
             }
         }
-    }
 
-    for (line_no, mutations) in (0..).zip(lines_mutations.iter_mut()) {
-        // Ignore the line if it's already inactivated during the pre-scan stage.
-        if !lines.info(line_no).is_active() {
+        // If line will be rejected in second pass, don't let it define a symbol.
+        let orig_state = state;
+        if state.transit_state(&lines.info(line_no), |_| {}).is_err() {
+            state = orig_state;
             continue;
         }
 
-        mutations.old_state = state;
-        mutations.old_before_imports = before_imports;
+        // Collect module-level symbols
+        let collect_result =
+            collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
+        if let Err(reason) = collect_result {
+            lines.set_active_status(line_no, Inactive(reason));
+            continue;
+        }
+    }
 
-        // Try to fix per-line syntax.
-        // Revert global changes and inactivate the line if syntax is invalid.
-        let mut ctx = SyntaxFixContext {
-            state: &mut state,
-            before_imports: &mut before_imports,
-            frame_stack: &mut frame_stack,
-            local_symbol_defs: &mut local_symbol_defs,
-            module_symbol_defs: &mut module_symbol_defs,
-        };
-        let line_fix_result = try_fix_line_syntax(line_no, lines, &mut ctx, mutations);
-        match line_fix_result {
-            Ok(_) => {
-                if mutations.clear_func {
-                    // Need to clear function-level stacks
-                    ctx.local_symbol_defs.clear();
-                    ctx.frame_stack.clear();
+    // second pass: disable other lines that would make module malformed
+    state = Initial;
+    for line_no in 0..lines.len() {
+        let line_kind = lines.info(line_no).kind.stripped_clone();
+
+        // Enforce correct symbolic reference consumption
+        if lines.info(line_no).is_active() {
+            // end/else must match the label of the frame being closed, not any enclosing frame
+            let label_symbol_defs: Vec<String> = match line_kind {
+                LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => frame_stack
+                    .last()
+                    .and_then(|(_, label)| label.clone())
+                    .into_iter()
+                    .collect(),
+                _ => frame_stack
+                    .iter()
+                    .filter_map(|(_, label)| label.clone())
+                    .collect(),
+            };
+            if !symbols_resolved(
+                &lines.info(line_no).symbols,
+                &module_symbol_defs,
+                &local_symbol_defs,
+                &label_symbol_defs,
+            ) {
+                lines.set_active_status(line_no, Inactive("undefined symbolic reference"));
+                continue;
+            }
+        }
+
+        // Fixup instructions that appear where they don't belong
+        if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
+            match state {
+                // Fix #1: Disable an instruction that appears in an imported function, skipping to next line
+                AfterFuncHeader(FuncHeader {
+                    is_import: true, ..
+                }) => {
+                    lines.set_active_status(
+                        line_no,
+                        Inactive("imported functions cannot have instructions"),
+                    );
+                    continue;
                 }
+                // Fix #2: prepend "(func" if an instruction appears at module scope
+                Initial => lines.set_synthetic_before(
+                    line_no,
+                    SyntheticWasm {
+                        module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
+                        ..Default::default()
+                    },
+                ),
+                // Fix #3: prepend "func" if an instruction appears after just "("
+                AfterModuleFieldLParen => lines.set_synthetic_before(
+                    line_no,
+                    SyntheticWasm {
+                        module_field_syntax: vec![ModulePart::FuncKeyword],
+                        ..Default::default()
+                    },
+                ),
+                _ => {}
+            }
+        }
 
-                // Record the line if it uses any module-level symbols
-                for sym_ref in &lines.info(line_no).symbols.consumes {
-                    if ctx
-                        .module_symbol_defs
-                        .contains(&sym_ref.space, &sym_ref.name)
-                    {
-                        module_symbol_users
-                            .entry((sym_ref.space.clone(), sym_ref.name.clone()))
-                            .or_default()
-                            .push(line_no);
+        // Process the line and transition the syntax state
+        let orig_state = state;
+        {
+            let res = state.transit_state(&lines.info(line_no), |_| {});
+            match res {
+                Ok(()) => {
+                    if state == Initial {
+                        // Fix #4: at end of function body, synthetically close all open frames
+                        lines.set_synthetic_before(
+                            line_no,
+                            SyntheticWasm {
+                                end_opcodes: frame_stack.len(),
+                                ..Default::default()
+                            },
+                        );
+                        frame_stack.clear();
+                        local_symbol_defs.clear();
                     }
+                }
+                Err(e) => {
+                    // If state transition is unacceptable here, disable line, revert state, and skip to next line
+                    lines.set_active_status(line_no, Inactive(e));
+                    state = orig_state;
+                    continue;
                 }
             }
-            Err(reason) => {
-                lines.set_active_status(line_no, Inactive(reason));
-                mutations.revert(&mut ctx);
+        }
 
-                // Inactivate the dangling module-level symbol users
-                for sym in &mutations.module_symbols {
-                    let Some(users) = module_symbol_users.get(sym) else {
-                        continue;
-                    };
-                    for &user_lineno in users {
-                        if lines.info(user_lineno).is_active() {
-                            lines.set_active_status(
-                                user_lineno,
-                                Inactive("undefined symbolic reference"),
-                            );
-                        }
+        // Enforce syntax requirements of structured instructions
+        if let LineKind::Instr(instr_kind) = line_kind {
+            match instr_kind {
+                // For a structured instruction that opens a frame, log this.
+                InstrKind::If | InstrKind::Loop | InstrKind::OtherStructured => {
+                    lines.set_active_status(line_no, Active);
+                    frame_stack.push((
+                        instr_kind,
+                        collect_label_symbol(&lines.info(line_no).symbols),
+                    ));
+                }
+
+                // Fix #5: if an `else` appears outside an `if` frame, disable it
+                InstrKind::Else => {
+                    if let Some((InstrKind::If, _)) = frame_stack.last() {
+                        lines.set_active_status(line_no, Active);
+                        // Carry over labels from If frame
+                        let (_, if_label) = frame_stack.pop().unwrap();
+                        frame_stack.push((InstrKind::Else, if_label));
+                    } else {
+                        lines.set_active_status(line_no, Inactive("‘else’ outside ‘if’"));
                     }
                 }
+
+                // Fix #6: if an `end` appears outside a frame, disable it
+                InstrKind::End => lines.set_active_status(
+                    line_no,
+                    if frame_stack.pop().is_some() {
+                        Active
+                    } else {
+                        Inactive("nothing to end")
+                    },
+                ),
+                InstrKind::Other => (),
+            }
+        }
+
+        // Collect defined local symbolic references if there's any.
+        // This collection should be after the state transition, because both of them can
+        // inactivate a line and need to revert the state and/or remove collected symbols after
+        // the inactivation. Reverting state is much simpler than removing symbols.
+        if lines.info(line_no).is_active() {
+            let collect_result =
+                collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
+            if let Err(reason) = collect_result {
+                // Inactivate line and revert state
+                lines.set_active_status(line_no, Inactive(reason));
+                state = orig_state;
+                continue;
             }
         }
     }
 
-    // Global syntax fixes.
-    // WARNING: Below this point, don't inactivate lines any more!
     match state {
         // Fix #7: if ending with "(" state, close with "func)"
         AfterModuleFieldLParen => {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -866,7 +866,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     // Pre-scan: settle "global" states that must be known before per-line fixes, including
     // - initialize per-line info;
     // - collect all module-level symbols for forward reference resolution.
-    for line_no in 0..lines.len() {
+    for (line_no, mutations) in (0..).zip(lines_mutations.iter_mut()) {
         // Initialize per-line info
         lines.set_synthetic_before(line_no, SyntheticWasm::default());
         lines.set_active_status(line_no, Active);
@@ -880,7 +880,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             Ok(added) => {
                 // Add the symbol collection to LineMutations. If the line is inactivated later,
                 // the inserted symbols will be removed.
-                lines_mutations[line_no].module_symbols.extend(added);
+                mutations.module_symbols.extend(added);
             }
             Err(reason) => {
                 // Symbols are not collected. There's no global change so reversion is not needed,
@@ -890,14 +890,14 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
         }
     }
 
-    for line_no in 0..lines.len() {
+    for (line_no, mutations) in (0..).zip(lines_mutations.iter_mut()) {
         // Ignore the line if it's already inactivated during the pre-scan stage.
         if !lines.info(line_no).is_active() {
             continue;
         }
 
-        lines_mutations[line_no].old_state = state;
-        lines_mutations[line_no].old_before_imports = before_imports;
+        mutations.old_state = state;
+        mutations.old_before_imports = before_imports;
 
         // Try to fix per-line syntax.
         // Revert global changes and inactivate the line if syntax is invalid.
@@ -909,10 +909,10 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             module_symbol_defs: &mut module_symbol_defs,
         };
         let line_fix_result =
-            try_fix_line_syntax(line_no, lines, &mut ctx, &mut lines_mutations[line_no]);
+            try_fix_line_syntax(line_no, lines, &mut ctx, mutations);
         match line_fix_result {
             Ok(_) => {
-                if lines_mutations[line_no].clear_func {
+                if mutations.clear_func {
                     // Need to clear function-level stacks
                     ctx.local_symbol_defs.clear();
                     ctx.frame_stack.clear();
@@ -933,10 +933,10 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             }
             Err(reason) => {
                 lines.set_active_status(line_no, Inactive(reason));
-                lines_mutations[line_no].revert(&mut ctx);
+                mutations.revert(&mut ctx);
 
                 // Inactivate the dangling module-level symbol users
-                for sym in &lines_mutations[line_no].module_symbols {
+                for sym in &mutations.module_symbols {
                     let Some(users) = module_symbol_users.get(sym) else {
                         continue;
                     };

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -6,7 +6,7 @@ use crate::symbolic::{
     collect_module_symbols, symbols_resolved,
 };
 use anyhow::Result;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use wast::{
     Error,
@@ -747,21 +747,36 @@ fn try_fix_line_syntax(
                 return Err("imported functions cannot have instructions");
             }
             // Fix #2: prepend "(func" if an instruction appears at module scope
-            Initial => lines.set_synthetic_before(
-                line_no,
-                SyntheticWasm {
-                    module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
-                    ..Default::default()
-                },
-            ),
+            Initial => {
+                lines.set_synthetic_before(
+                    line_no,
+                    SyntheticWasm {
+                        module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
+                        ..Default::default()
+                    },
+                );
+                // Synthetic ends take effect even if the line is inactivated
+                // old_state should reflect the states *after* synthetic ends
+                mutations.old_state = AfterFuncHeader(FuncHeader {
+                    is_import: false,
+                    next_field: 1,
+                });
+            }
             // Fix #3: prepend "func" if an instruction appears after just "("
-            AfterModuleFieldLParen => lines.set_synthetic_before(
-                line_no,
-                SyntheticWasm {
-                    module_field_syntax: vec![ModulePart::FuncKeyword],
-                    ..Default::default()
-                },
-            ),
+            AfterModuleFieldLParen => {
+                lines.set_synthetic_before(
+                    line_no,
+                    SyntheticWasm {
+                        module_field_syntax: vec![ModulePart::FuncKeyword],
+                        ..Default::default()
+                    },
+                );
+                // Subsequent passes process this synthetic even for inactive lines.
+                mutations.old_state = AfterFuncHeader(FuncHeader {
+                    is_import: false,
+                    next_field: 1,
+                });
+            }
             _ => {}
         }
     }
@@ -779,6 +794,8 @@ fn try_fix_line_syntax(
             },
         );
         mutations.clear_func = true;
+        // old_state should reflect the states *after* synthetic ends
+        mutations.old_state = Initial;
     }
 
     // Enforce syntax requirements of structured instructions
@@ -837,6 +854,11 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     // Structures for symbolic references
     let mut module_symbol_defs = ModuleIdentifiers::default();
     let mut local_symbol_defs: HashSet<String> = HashSet::new();
+
+    // Map a module-level symbol to its users' line numbers
+    // When a *forward* module-level symbol's def line is inactivated, the backward
+    // users' lines need to be inactivated also due to undefined symbolic reference
+    let mut module_symbol_users: HashMap<(IndexSpace, String), Vec<usize>> = HashMap::new();
 
     assert!(lines.len() > 0);
 
@@ -899,6 +921,16 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                     local_symbol_defs.clear();
                     frame_stack.clear();
                 }
+
+                // Record the line if it uses any module-level symbols
+                for sym_ref in &lines.info(line_no).symbols.consumes {
+                    if module_symbol_defs.contains(&sym_ref.space, &sym_ref.name) {
+                        module_symbol_users
+                            .entry((sym_ref.space.clone(), sym_ref.name.clone()))
+                            .or_default()
+                            .push(line_no);
+                    }
+                }
             }
             Err(reason) => {
                 lines.set_active_status(line_no, Inactive(reason));
@@ -909,6 +941,21 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                     &mut local_symbol_defs,
                     &mut module_symbol_defs,
                 );
+
+                // Inactivate the dangling module-level symbol users
+                for sym in &lines_mutations[line_no].module_symbols {
+                    let Some(users) = module_symbol_users.get(&sym) else {
+                        continue;
+                    };
+                    for &user_lineno in users {
+                        if lines.info(user_lineno).is_active() {
+                            lines.set_active_status(
+                                user_lineno,
+                                Inactive("undefined symbolic reference"),
+                            );
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -633,6 +633,14 @@ struct LineMutations {
     clear_func: bool,          // clear func-scope states?
 }
 
+struct SyntaxFixContext<'a> {
+    state: &'a mut SyntaxState,
+    before_imports: &'a mut bool,
+    local_symbol_defs: &'a mut HashSet<String>,
+    module_symbol_defs: &'a mut ModuleIdentifiers,
+    frame_stack: &'a mut Vec<(InstrKind, Option<String>)>,
+}
+
 impl LineMutations {
     fn new() -> Self {
         Self {
@@ -645,35 +653,26 @@ impl LineMutations {
         }
     }
 
-    // Revert line/global changes in fix_syntax.
-    // This function should be called when the line is inactivated.
-    fn revert(
-        &self,
-        state: &mut SyntaxState,
-        before_imports: &mut bool,
-        frame_stack: &mut Vec<(InstrKind, Option<String>)>,
-        local_symbol_defs: &mut HashSet<String>,
-        module_symbol_defs: &mut ModuleIdentifiers,
-    ) {
-        *state = self.old_state;
-        *before_imports = self.old_before_imports;
+    fn revert(&self, ctx: &mut SyntaxFixContext<'_>) {
+        *ctx.state = self.old_state;
+        *ctx.before_imports = self.old_before_imports;
 
         for (space, name) in &self.module_symbols {
-            module_symbol_defs.remove(&space, &name);
+            ctx.module_symbol_defs.remove(space, name);
         }
         for sym in &self.local_symbols {
-            local_symbol_defs.remove(sym);
+            ctx.local_symbol_defs.remove(sym);
         }
 
         match &self.frame_change {
             FrameChange::None => {}
             FrameChange::Pushed => {
-                frame_stack.pop();
+                ctx.frame_stack.pop();
             }
-            FrameChange::Popped(kind, label) => frame_stack.push((*kind, label.clone())),
+            FrameChange::Popped(kind, label) => ctx.frame_stack.push((*kind, label.clone())),
             FrameChange::ReplacedIfWithElse(label) => {
-                frame_stack.pop();
-                frame_stack.push((InstrKind::If, label.clone()));
+                ctx.frame_stack.pop();
+                ctx.frame_stack.push((InstrKind::If, label.clone()));
             }
         }
     }
@@ -686,11 +685,7 @@ impl LineMutations {
 fn try_fix_line_syntax(
     line_no: usize,
     lines: &mut impl LineInfosMut,
-    state: &mut SyntaxState,
-    before_imports: &mut bool,
-    frame_stack: &mut Vec<(InstrKind, Option<String>)>,
-    local_symbol_defs: &mut HashSet<String>,
-    module_symbol_defs: &mut ModuleIdentifiers,
+    ctx: &mut SyntaxFixContext<'_>,
     mutations: &mut LineMutations,
 ) -> Result<(), &'static str> {
     use SyntaxState::*;
@@ -709,29 +704,31 @@ fn try_fix_line_syntax(
             )
         });
 
-        if has_import && !*before_imports {
+        if has_import && !*ctx.before_imports {
             return Err("imports must appear before other module fields");
         } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
-            *before_imports = false;
+            *ctx.before_imports = false;
         }
     }
 
     // Enforce correct symbolic reference consumption
     let label_symbol_defs: Vec<String> = match &line_kind {
-        LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => frame_stack
+        LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => ctx
+            .frame_stack
             .last()
             .and_then(|(_, label)| label.clone())
             .into_iter()
             .collect(),
-        _ => frame_stack
+        _ => ctx
+            .frame_stack
             .iter()
             .filter_map(|(_, label)| label.clone())
             .collect(),
     };
     if !symbols_resolved(
         &lines.info(line_no).symbols,
-        module_symbol_defs,
-        local_symbol_defs,
+        ctx.module_symbol_defs,
+        ctx.local_symbol_defs,
         &label_symbol_defs,
     ) {
         return Err("undefined symbolic reference");
@@ -739,7 +736,7 @@ fn try_fix_line_syntax(
 
     // Fixup instructions that appear where they don't belong
     if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
-        match state {
+        match ctx.state {
             // Fix #1: Disable an instruction that appears in an imported function
             AfterFuncHeader(FuncHeader {
                 is_import: true, ..
@@ -782,14 +779,14 @@ fn try_fix_line_syntax(
     }
 
     // Process the line and transition the syntax state
-    state.transit_state(&lines.info(line_no), |_| {})?;
+    ctx.state.transit_state(&lines.info(line_no), |_| {})?;
 
-    if *state == Initial {
+    if *ctx.state == Initial {
         // Fix #4: at end of function body, synthetically close all open frames
         lines.set_synthetic_before(
             line_no,
             SyntheticWasm {
-                end_opcodes: frame_stack.len(),
+                end_opcodes: ctx.frame_stack.len(),
                 ..Default::default()
             },
         );
@@ -804,16 +801,16 @@ fn try_fix_line_syntax(
             // For a structured instruction that opens a frame, log this.
             InstrKind::If | InstrKind::Loop | InstrKind::OtherStructured => {
                 let label = collect_label_symbol(&lines.info(line_no).symbols);
-                frame_stack.push((instr_kind, label.clone()));
+                ctx.frame_stack.push((instr_kind, label.clone()));
                 mutations.frame_change = FrameChange::Pushed;
             }
 
             // Fix #5: if an `else` appears outside an `if` frame, disable it
             InstrKind::Else => {
-                if let Some((InstrKind::If, _)) = frame_stack.last() {
+                if let Some((InstrKind::If, _)) = ctx.frame_stack.last() {
                     // Carry over labels from If frame
-                    let (_, if_label) = frame_stack.pop().unwrap();
-                    frame_stack.push((InstrKind::Else, if_label.clone()));
+                    let (_, if_label) = ctx.frame_stack.pop().unwrap();
+                    ctx.frame_stack.push((InstrKind::Else, if_label.clone()));
                     mutations.frame_change = FrameChange::ReplacedIfWithElse(if_label);
                 } else {
                     return Err("'else' outside 'if'");
@@ -822,7 +819,7 @@ fn try_fix_line_syntax(
 
             // Fix #6: if an `end` appears outside a frame, disable it
             InstrKind::End => {
-                if let Some(popped) = frame_stack.pop() {
+                if let Some(popped) = ctx.frame_stack.pop() {
                     mutations.frame_change = FrameChange::Popped(popped.0, popped.1);
                 } else {
                     return Err("nothing to end");
@@ -833,7 +830,7 @@ fn try_fix_line_syntax(
     }
 
     // Collect defined local symbolic references
-    let added = collect_local_symbols(&lines.info(line_no).symbols, local_symbol_defs)?;
+    let added = collect_local_symbols(&lines.info(line_no).symbols, ctx.local_symbol_defs)?;
     mutations.local_symbols.extend(added);
 
     Ok(())
@@ -904,27 +901,29 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
         // Try to fix per-line syntax.
         // Revert global changes and inactivate the line if syntax is invalid.
-        let line_fix_result = try_fix_line_syntax(
-            line_no,
-            lines,
-            &mut state,
-            &mut before_imports,
-            &mut frame_stack,
-            &mut local_symbol_defs,
-            &mut module_symbol_defs,
-            &mut lines_mutations[line_no],
-        );
+        let mut ctx = SyntaxFixContext {
+            state: &mut state,
+            before_imports: &mut before_imports,
+            frame_stack: &mut frame_stack,
+            local_symbol_defs: &mut local_symbol_defs,
+            module_symbol_defs: &mut module_symbol_defs,
+        };
+        let line_fix_result =
+            try_fix_line_syntax(line_no, lines, &mut ctx, &mut lines_mutations[line_no]);
         match line_fix_result {
             Ok(_) => {
                 if lines_mutations[line_no].clear_func {
                     // Need to clear function-level stacks
-                    local_symbol_defs.clear();
-                    frame_stack.clear();
+                    ctx.local_symbol_defs.clear();
+                    ctx.frame_stack.clear();
                 }
 
                 // Record the line if it uses any module-level symbols
                 for sym_ref in &lines.info(line_no).symbols.consumes {
-                    if module_symbol_defs.contains(&sym_ref.space, &sym_ref.name) {
+                    if ctx
+                        .module_symbol_defs
+                        .contains(&sym_ref.space, &sym_ref.name)
+                    {
                         module_symbol_users
                             .entry((sym_ref.space.clone(), sym_ref.name.clone()))
                             .or_default()
@@ -934,17 +933,11 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             }
             Err(reason) => {
                 lines.set_active_status(line_no, Inactive(reason));
-                lines_mutations[line_no].revert(
-                    &mut state,
-                    &mut before_imports,
-                    &mut frame_stack,
-                    &mut local_symbol_defs,
-                    &mut module_symbol_defs,
-                );
+                lines_mutations[line_no].revert(&mut ctx);
 
                 // Inactivate the dangling module-level symbol users
                 for sym in &lines_mutations[line_no].module_symbols {
-                    let Some(users) = module_symbol_users.get(&sym) else {
+                    let Some(users) = module_symbol_users.get(sym) else {
                         continue;
                     };
                     for &user_lineno in users {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,7 +2,7 @@
 
 use crate::line::LineInfo;
 use crate::symbolic::{
-    ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
+    IndexSpace, ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
     symbols_resolved,
 };
 use anyhow::Result;
@@ -608,7 +608,65 @@ impl SyntaxState {
     }
 }
 
-/// Fix frames (and missing function beginning and end) by deactivating
+// LineMutations stores the changes for a line in fix_syntax, enabling rollback.
+// In fix_syntax, global changes, including
+// - state transition
+// - symbolic reference collection
+// - frame_stack operations,
+// need to be reverted if the line is eventually inactivated.
+// Note: Line changes such as setting synthetic_before doesn't strictly need to be 
+//       reverted because they won't take effect for inactive lines.
+enum FrameChange {
+    None,
+    Pushed(InstrKind, Option<String>),
+    Popped(InstrKind, Option<String>),
+    ReplacedIfWithElse(Option<String>),
+}
+
+struct LineMutations {
+    old_state: SyntaxState,
+    module_symbols: Vec<(IndexSpace, String)>,
+    local_symbols: Vec<String>,
+    frame_change: FrameChange,
+}
+
+impl LineMutations {
+    // Revert line/global changes in fix_syntax.
+    // This function should be called when the line is inactivated.
+    fn revert(
+        self,
+        line_no: usize,
+        lines: &mut impl LineInfosMut,
+        state: &mut SyntaxState,
+        frame_stack: &mut Vec<(InstrKind, Option<String>)>,
+        local_symbol_defs: &mut HashSet<String>,
+        module_symbol_defs: &mut ModuleIdentifiers,
+    ) {
+        // Revert SyntaxState
+        *state = self.old_state;
+
+        // Revert symbol collections
+        for (space, name) in self.module_symbols { 
+            module_symbol_defs.remove(&space, &name);
+        }
+        for sym in self.local_symbols { 
+            local_symbol_defs.remove(&sym);
+        }
+
+        // Revert frame stack
+        match self.frame_change {
+            FrameChange::None => {}
+            FrameChange::Pushed(_, _) => { frame_stack.pop(); }
+            FrameChange::Popped(kind, label) => frame_stack.push((kind, label)),
+            FrameChange::ReplacedIfWithElse(label) => {
+                frame_stack.pop();
+                frame_stack.push((InstrKind::If, label));
+            }
+        }
+    }
+}
+
+/// Fix frames (and missing function beginning and end) by deactivating,
 /// unmatched ends, appending ends as necessary to close open
 /// frames, prepending "(" and "func" and appending ")" as necessary, etc.
 pub fn fix_syntax(lines: &mut impl LineInfosMut) {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -619,7 +619,7 @@ impl SyntaxState {
 //       reverted because they won't take effect for inactive lines.
 enum FrameChange {
     None,
-    Pushed(InstrKind, Option<String>),
+    Pushed,
     Popped(InstrKind, Option<String>),
     ReplacedIfWithElse(Option<String>),
 }
@@ -629,14 +629,26 @@ struct LineMutations {
     old_before_imports: bool,
     module_symbols: Vec<(IndexSpace, String)>,
     local_symbols: Vec<String>,
-    frame_change: FrameChange,
+    frame_change: FrameChange, // frame_stack changes
+    clear_func: bool,          // clear func-scope states?
 }
 
 impl LineMutations {
+    fn new() -> Self {
+        Self {
+            old_state: SyntaxState::Initial,
+            old_before_imports: false,
+            module_symbols: Vec::new(),
+            local_symbols: Vec::new(),
+            frame_change: FrameChange::None,
+            clear_func: false,
+        }
+    }
+
     // Revert line/global changes in fix_syntax.
     // This function should be called when the line is inactivated.
     fn revert(
-        self,
+        &self,
         state: &mut SyntaxState,
         before_imports: &mut bool,
         frame_stack: &mut Vec<(InstrKind, Option<String>)>,
@@ -646,20 +658,22 @@ impl LineMutations {
         *state = self.old_state;
         *before_imports = self.old_before_imports;
 
-        for (space, name) in self.module_symbols {
+        for (space, name) in &self.module_symbols {
             module_symbol_defs.remove(&space, &name);
         }
-        for sym in self.local_symbols {
-            local_symbol_defs.remove(&sym);
+        for sym in &self.local_symbols {
+            local_symbol_defs.remove(sym);
         }
 
-        match self.frame_change {
+        match &self.frame_change {
             FrameChange::None => {}
-            FrameChange::Pushed(_, _) => { frame_stack.pop(); }
-            FrameChange::Popped(kind, label) => frame_stack.push((kind, label)),
+            FrameChange::Pushed => {
+                frame_stack.pop();
+            }
+            FrameChange::Popped(kind, label) => frame_stack.push((*kind, label.clone())),
             FrameChange::ReplacedIfWithElse(label) => {
                 frame_stack.pop();
-                frame_stack.push((InstrKind::If, label));
+                frame_stack.push((InstrKind::If, label.clone()));
             }
         }
     }
@@ -669,28 +683,21 @@ impl LineMutations {
 // Accumulate changes into mutations as it proceeds.
 // Return Err if the line should be inactivated; the caller is responsible for
 // calling mutations.revert() to undo any partial changes.
-fn try_fix_syntax(
+fn try_fix_line_syntax(
     line_no: usize,
     lines: &mut impl LineInfosMut,
     state: &mut SyntaxState,
+    before_imports: &mut bool,
     frame_stack: &mut Vec<(InstrKind, Option<String>)>,
     local_symbol_defs: &mut HashSet<String>,
     module_symbol_defs: &mut ModuleIdentifiers,
-    before_imports: &mut bool,
     mutations: &mut LineMutations,
 ) -> Result<(), &'static str> {
-    use crate::line::Activity::*;
     use SyntaxState::*;
-
-    mutations.old_state = *state;
-    mutations.old_before_imports = *before_imports;
-    mutations.module_symbols.clear();
-    mutations.local_symbols.clear();
-    mutations.frame_change = FrameChange::None;
 
     let line_kind = lines.info(line_no).kind.stripped_clone();
 
-    // Enforce no imports after other module fields, and collect module-level symbols
+    // Enforce no imports after other module fields
     if let LineKind::Other(parts) = &line_kind {
         let has_import = parts
             .iter()
@@ -698,10 +705,7 @@ fn try_fix_syntax(
         let module_field = parts.iter().any(|&p| {
             matches!(
                 p,
-                ModulePart::Memory
-                    | ModulePart::Table
-                    | ModulePart::Global
-                    | ModulePart::Export
+                ModulePart::Memory | ModulePart::Table | ModulePart::Global | ModulePart::Export
             )
         });
 
@@ -710,9 +714,6 @@ fn try_fix_syntax(
         } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
             *before_imports = false;
         }
-
-        let added = collect_module_symbols(&lines.info(line_no).symbols, module_symbol_defs)?;
-        mutations.module_symbols.extend(added);
     }
 
     // Enforce correct symbolic reference consumption
@@ -740,7 +741,9 @@ fn try_fix_syntax(
     if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
         match state {
             // Fix #1: Disable an instruction that appears in an imported function
-            AfterFuncHeader(FuncHeader { is_import: true, .. }) => {
+            AfterFuncHeader(FuncHeader {
+                is_import: true, ..
+            }) => {
                 return Err("imported functions cannot have instructions");
             }
             // Fix #2: prepend "(func" if an instruction appears at module scope
@@ -775,9 +778,7 @@ fn try_fix_syntax(
                 ..Default::default()
             },
         );
-        frame_stack.clear();
-        local_symbol_defs.clear();
-        return Ok(());
+        mutations.clear_func = true;
     }
 
     // Enforce syntax requirements of structured instructions
@@ -787,12 +788,13 @@ fn try_fix_syntax(
             InstrKind::If | InstrKind::Loop | InstrKind::OtherStructured => {
                 let label = collect_label_symbol(&lines.info(line_no).symbols);
                 frame_stack.push((instr_kind, label.clone()));
-                mutations.frame_change = FrameChange::Pushed(instr_kind, label);
+                mutations.frame_change = FrameChange::Pushed;
             }
 
             // Fix #5: if an `else` appears outside an `if` frame, disable it
             InstrKind::Else => {
                 if let Some((InstrKind::If, _)) = frame_stack.last() {
+                    // Carry over labels from If frame
                     let (_, if_label) = frame_stack.pop().unwrap();
                     frame_stack.push((InstrKind::Else, if_label.clone()));
                     mutations.frame_change = FrameChange::ReplacedIfWithElse(if_label);
@@ -838,195 +840,81 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
     assert!(lines.len() > 0);
 
-    // first pass: disable imports appearing after other module fields,
-    // and declare module-scope symbolic ids for any surviving lines.
+    // "Global" changes from each line
+    let mut lines_mutations: Vec<LineMutations> =
+        (0..lines.len()).map(|_| LineMutations::new()).collect();
 
-    // There are probably still cases that can produce a "bounce."
+    // Pre-scan: settle "global" states that must be known before per-line fixes, including
+    // - initialize per-line info;
+    // - collect all module-level symbols for forward reference resolution.
     for line_no in 0..lines.len() {
+        // Initialize per-line info
         lines.set_synthetic_before(line_no, SyntheticWasm::default());
         lines.set_active_status(line_no, Active);
         lines.set_invalid(line_no, None);
         lines.set_runtime_error(line_no, None);
 
-        let line_kind = lines.info(line_no).kind.stripped_clone();
-
-        // Enforce no imports after other module fields
-        if let LineKind::Other(parts) = &line_kind {
-            let has_import = parts
-                .iter()
-                .any(|&p| matches!(p, ModulePart::Import | ModulePart::InlineImport));
-            let module_field = parts.iter().any(|&p| {
-                matches!(
-                    p,
-                    ModulePart::Memory
-                        | ModulePart::Table
-                        | ModulePart::Global
-                        | ModulePart::Export
-                )
-            });
-            if has_import && !before_imports {
-                lines.set_active_status(
-                    line_no,
-                    Inactive("imports must appear before other module fields"),
-                );
-                continue;
-            } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
-                before_imports = false;
+        // Collect module-level symbols
+        let collect_result =
+            collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
+        match collect_result {
+            Ok(added) => {
+                // Add the symbol collection to LineMutations. If the line is inactivated later,
+                // the inserted symbols will be removed.
+                lines_mutations[line_no].module_symbols.extend(added);
             }
-
-            // Collect module-level symbols
-            let collect_result =
-                collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
-            if let Err(reason) = collect_result {
+            Err(reason) => {
+                // Symbols are not collected. There's no global change so reversion is not needed,
+                // Inactivate the line directly,
                 lines.set_active_status(line_no, Inactive(reason));
-                continue;
             }
         }
     }
 
-    // second pass: disable other lines that would make module malformed
     for line_no in 0..lines.len() {
-        let line_kind = lines.info(line_no).kind.stripped_clone();
-
-        // Enforce correct symbolic reference consumption
-        if lines.info(line_no).is_active() {
-            // end/else must match the label of the frame being closed, not any enclosing frame
-            let label_symbol_defs: Vec<String> = match line_kind {
-                LineKind::Instr(InstrKind::End) | LineKind::Instr(InstrKind::Else) => frame_stack
-                    .last()
-                    .and_then(|(_, label)| label.clone())
-                    .into_iter()
-                    .collect(),
-                _ => frame_stack
-                    .iter()
-                    .filter_map(|(_, label)| label.clone())
-                    .collect(),
-            };
-            if !symbols_resolved(
-                &lines.info(line_no).symbols,
-                &module_symbol_defs,
-                &local_symbol_defs,
-                &label_symbol_defs,
-            ) {
-                lines.set_active_status(line_no, Inactive("undefined symbolic reference"));
-                continue;
-            }
+        // Ignore the line if it's already inactivated during the pre-scan stage.
+        if !lines.info(line_no).is_active() {
+            continue;
         }
 
-        // Fixup instructions that appear where they don't belong
-        if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
-            match state {
-                // Fix #1: Disable an instruction that appears in an imported function, skipping to next line
-                AfterFuncHeader(FuncHeader {
-                    is_import: true, ..
-                }) => {
-                    lines.set_active_status(
-                        line_no,
-                        Inactive("imported functions cannot have instructions"),
-                    );
-                    continue;
-                }
-                // Fix #2: prepend "(func" if an instruction appears at module scope
-                Initial => lines.set_synthetic_before(
-                    line_no,
-                    SyntheticWasm {
-                        module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
-                        ..Default::default()
-                    },
-                ),
-                // Fix #3: prepend "func" if an instruction appears after just "("
-                AfterModuleFieldLParen => lines.set_synthetic_before(
-                    line_no,
-                    SyntheticWasm {
-                        module_field_syntax: vec![ModulePart::FuncKeyword],
-                        ..Default::default()
-                    },
-                ),
-                _ => {}
-            }
-        }
+        lines_mutations[line_no].old_state = state;
+        lines_mutations[line_no].old_before_imports = before_imports;
 
-        // Process the line and transition the syntax state
-        let orig_state = state;
-        {
-            let res = state.transit_state(&lines.info(line_no), |_| {});
-            match res {
-                Ok(()) => {
-                    if state == Initial {
-                        // Fix #4: at end of function body, synthetically close all open frames
-                        lines.set_synthetic_before(
-                            line_no,
-                            SyntheticWasm {
-                                end_opcodes: frame_stack.len(),
-                                ..Default::default()
-                            },
-                        );
-                        frame_stack.clear();
-                        local_symbol_defs.clear();
-                    }
-                }
-                Err(e) => {
-                    // If state transition is unacceptable here, disable line, revert state, and skip to next line
-                    lines.set_active_status(line_no, Inactive(e));
-                    state = orig_state;
-                    continue;
+        // Try to fix per-line syntax.
+        // Revert global changes and inactivate the line if syntax is invalid.
+        let line_fix_result = try_fix_line_syntax(
+            line_no,
+            lines,
+            &mut state,
+            &mut before_imports,
+            &mut frame_stack,
+            &mut local_symbol_defs,
+            &mut module_symbol_defs,
+            &mut lines_mutations[line_no],
+        );
+        match line_fix_result {
+            Ok(_) => {
+                if lines_mutations[line_no].clear_func {
+                    // Need to clear function-level stacks
+                    local_symbol_defs.clear();
+                    frame_stack.clear();
                 }
             }
-        }
-
-        // Enforce syntax requirements of structured instructions
-        if let LineKind::Instr(instr_kind) = line_kind {
-            match instr_kind {
-                // For a structured instruction that opens a frame, log this.
-                InstrKind::If | InstrKind::Loop | InstrKind::OtherStructured => {
-                    lines.set_active_status(line_no, Active);
-                    frame_stack.push((
-                        instr_kind,
-                        collect_label_symbol(&lines.info(line_no).symbols),
-                    ));
-                }
-
-                // Fix #5: if an `else` appears outside an `if` frame, disable it
-                InstrKind::Else => {
-                    if let Some((InstrKind::If, _)) = frame_stack.last() {
-                        lines.set_active_status(line_no, Active);
-                        // Carry over labels from If frame
-                        let (_, if_label) = frame_stack.pop().unwrap();
-                        frame_stack.push((InstrKind::Else, if_label));
-                    } else {
-                        lines.set_active_status(line_no, Inactive("‘else’ outside ‘if’"));
-                    }
-                }
-
-                // Fix #6: if an `end` appears outside a frame, disable it
-                InstrKind::End => lines.set_active_status(
-                    line_no,
-                    if frame_stack.pop().is_some() {
-                        Active
-                    } else {
-                        Inactive("nothing to end")
-                    },
-                ),
-                InstrKind::Other => (),
-            }
-        }
-
-        // Collect defined local symbolic references if there's any.
-        // This collection should be after the state transition, because both of them can
-        // inactivate a line and need to revert the state and/or remove collected symbols after
-        // the inactivation. Reverting state is much simpler than removing symbols.
-        if lines.info(line_no).is_active() {
-            let collect_result =
-                collect_local_symbols(&lines.info(line_no).symbols, &mut local_symbol_defs);
-            if let Err(reason) = collect_result {
-                // Inactivate line and revert state
+            Err(reason) => {
                 lines.set_active_status(line_no, Inactive(reason));
-                state = orig_state;
-                continue;
+                lines_mutations[line_no].revert(
+                    &mut state,
+                    &mut before_imports,
+                    &mut frame_stack,
+                    &mut local_symbol_defs,
+                    &mut module_symbol_defs,
+                );
             }
         }
     }
 
+    // Global syntax fixes.
+    // WARNING: Below this point, don't inactivate lines any more!
     match state {
         // Fix #7: if ending with "(" state, close with "func)"
         AfterModuleFieldLParen => {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -908,8 +908,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
             local_symbol_defs: &mut local_symbol_defs,
             module_symbol_defs: &mut module_symbol_defs,
         };
-        let line_fix_result =
-            try_fix_line_syntax(line_no, lines, &mut ctx, mutations);
+        let line_fix_result = try_fix_line_syntax(line_no, lines, &mut ctx, mutations);
         match line_fix_result {
             Ok(_) => {
                 if mutations.clear_func {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3179,6 +3179,28 @@ pub(crate) mod tests {
         }
 
         {
+            // issue #226 case 1
+            let mut editor = FakeTextBuffer::default();
+            editor.push_line("(func");
+            editor.push_line("call $g");
+            editor.push_line(")");
+            editor.push_line("(func $g (param i32) (result i32))");
+            test_editor_flow(&mut editor)?;
+        }
+
+        {
+            // issue #226 case 2
+            let mut editor = FakeTextBuffer::default();
+            editor.push_line("(func $draw (import \"draw\" \"point\") (param f64 f64)");
+            editor.push_line("(func $f");
+            editor.push_line(")");
+            editor.push_line("(func");
+            editor.push_line("call $f");
+            editor.push_line(")");
+            test_editor_flow(&mut editor)?;
+        }
+
+        {
             let mut editor = FakeTextBuffer::default();
             editor.push_line("(func");
             editor.push_line("call $f");


### PR DESCRIPTION
### PR Summary
**Design of `struct LineMutations`:**
In `fix_syntax`, we do multiple "global" changes to a line (e.g., state transition, symbolic reference collection, frame_stack operation, etc.). These "global" changes should be **all or nothing**: all are applied if the line is active, and none if inactive. \
`LineMutations` records the necessary info for a line (e.g., original state, collected symbolic references, a pushed frame_stack, etc.), such that we can relatively easily revert all the mutations.
This struct looses the order of syntax fixes, making it less likely to crash when adding a new fix.

**try_fix_line_syntax:**
This helper function for `fix_syntax` holds the original fixes for **each line**, plus recording to `LineMutations`. When it returns an error with message to `fix_syntax`, we inactivate the line and do the `LineMutations.revert(...)` for this line.

**Fix for issue #226 :**
We track the consumer lines of module-level symbolic references. When a line with module-level symbolic reference (e.g., func id) is inactivated due other reasons like invalid func field, all backward consumers lines of such module symbol are all inactivated.

**Test cases in issue #226 are added to `test_fixes`**

Fixes: #226 