### PR TITLE
Memory track for ExecutionStep

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -210,9 +210,11 @@ pub enum MemoryOp {
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryAccess {
     pub op: MemoryOp,
+    pub mem_idx: u32,    // memory index
     pub addr_slot: u32,  // slot idx for address
+    pub offset: u64,     // concrete addr = slots[addr_slot] + offset
     pub byte_count: u8,  // can be 1, 2, 4, or 8
-    pub value_slot: u32, // slot idx for value
+    pub value_slot: u32, // slot idx for value (only for store)
 }
 
 #[derive(Default, Debug)]
@@ -380,7 +382,14 @@ fn create_graphics_helpers(draw: &Object) {
     register_closure(draw, "set_radius", set_radius);
 }
 
-fn record_memory_access(is_load: i32, addr_slot: u32, byte_count: u8, value_slot: u32) {
+fn record_memory_access(
+    is_load: i32,
+    mem_idx: u32,
+    addr_slot: u32,
+    offset: u64,
+    byte_count: u8,
+    value_slot: u32,
+) {
     with_current_step_mut(|step| {
         step.memory_access = Some(MemoryAccess {
             op: if is_load != 0 {
@@ -388,7 +397,9 @@ fn record_memory_access(is_load: i32, addr_slot: u32, byte_count: u8, value_slot
             } else {
                 MemoryOp::Store
             },
+            mem_idx,
             addr_slot,
+            offset,
             byte_count,
             value_slot,
         });
@@ -420,10 +431,22 @@ fn create_closure_record_operations(obj: &Object) {
     register_closure(obj, "record_f64", record_f64);
 
     let record_memory = Closure::wrap(Box::new(
-        move |is_load: i32, addr_slot: u32, byte_count: i32, value_slot: u32| {
-            record_memory_access(is_load, addr_slot, byte_count as u8, value_slot)
+        move |is_load: i32,
+              mem_idx: u32,
+              addr_slot: u32,
+              offset: i64,
+              byte_count: i32,
+              value_slot: u32| {
+            record_memory_access(
+                is_load,
+                mem_idx,
+                addr_slot,
+                offset as u64,
+                byte_count as u8,
+                value_slot,
+            )
         },
-    ) as Box<dyn Fn(i32, u32, i32, u32)>);
+    ) as Box<dyn Fn(i32, u32, u32, i64, i32, u32)>);
     register_closure(obj, "record_memory", record_memory);
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -207,9 +207,9 @@ struct ExecutionStep {
     line_num: u32,
     slot_assignments: SmallVec<[(u32, WasmValue); 1]>, // slot idx, value (SmallVec stores in-line if <=1 result)
     graphics_op: Option<Action>,
-    memory_access: Option<u32>, // index into MEMORY_OPS
-                                // XXX todo: clear any func/frame on entry
-                                // XXX todo: save any func on call/call_indirect, restore after
+    memory_access: Option<usize>, // index into static memory lookup table
+                                  // XXX todo: clear any func/frame on entry
+                                  // XXX todo: save any func on call/call_indirect, restore after
 }
 
 impl ExecutionStep {
@@ -268,6 +268,34 @@ impl ExecutionState {
             },
             error_string(),
         ));
+
+        // Reconstruct memory access
+        // TODO remove log message when it's visualized
+        if let Some(idx) = with_completed_step(target_step, |s| s.memory_access)
+            && let Some(mo) = self.memory_ops.get(idx)
+        {
+            let addr_operand = self.slots.get(mo.addr_slot).and_then(|s| *s).and_then(|v| {
+                if let WasmValue::I32(a) = v {
+                    Some(a as u32 as u64)
+                } else {
+                    None
+                }
+            });
+            let value = self.slots.get(mo.value_slot).and_then(|s| *s);
+            if let (Some(addr_operand), Some(value)) = (addr_operand, value) {
+                web_sys::console::log_1(
+                    &format!(
+                        "{:?} mem[{}]: addr={} ({} bytes) {:?}",
+                        mo.op,
+                        mo.mem_idx,
+                        addr_operand + mo.offset,
+                        mo.byte_count,
+                        value
+                    )
+                    .into(),
+                );
+            }
+        }
     }
 }
 
@@ -375,7 +403,7 @@ fn create_graphics_helpers(draw: &Object) {
     register_closure(draw, "set_radius", set_radius);
 }
 
-fn record_memory_access(index: u32) {
+fn record_memory_access(index: usize) {
     with_current_step_mut(|step| step.memory_access = Some(index));
 }
 
@@ -403,9 +431,10 @@ fn create_closure_record_operations(obj: &Object) {
     );
     register_closure(obj, "record_f64", record_f64);
 
-    let record_memory = Closure::wrap(
-        Box::new(move |index: i32| record_memory_access(index as u32)) as Box<dyn Fn(i32)>,
-    );
+    let record_memory =
+        Closure::wrap(
+            Box::new(move |index: i32| record_memory_access(index as usize)) as Box<dyn Fn(i32)>,
+        );
     register_closure(obj, "record_memory", record_memory);
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -211,9 +211,11 @@ pub enum MemoryOp {
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryAccess {
     pub op: MemoryOp,
+    pub mem_idx: u32,    // memory index
     pub addr_slot: u32,  // slot idx for address
+    pub offset: u64,     // concrete addr = slots[addr_slot] + offset
     pub byte_count: u8,  // can be 1, 2, 4, or 8
-    pub value_slot: u32, // slot idx for value
+    pub value_slot: u32, // slot idx for value (only for store)
 }
 
 #[derive(Default, Debug)]
@@ -388,7 +390,14 @@ fn create_graphics_helpers(draw: &Object) {
     register_closure(draw, "set_radius", set_radius);
 }
 
-fn record_memory_access(is_load: i32, addr_slot: u32, byte_count: u8, value_slot: u32) {
+fn record_memory_access(
+    is_load: i32,
+    mem_idx: u32,
+    addr_slot: u32,
+    offset: u64,
+    byte_count: u8,
+    value_slot: u32,
+) {
     with_current_step_mut(|step| {
         step.memory_access = Some(MemoryAccess {
             op: if is_load != 0 {
@@ -396,7 +405,9 @@ fn record_memory_access(is_load: i32, addr_slot: u32, byte_count: u8, value_slot
             } else {
                 MemoryOp::Store
             },
+            mem_idx,
             addr_slot,
+            offset,
             byte_count,
             value_slot,
         });
@@ -428,10 +439,22 @@ fn create_closure_record_operations(obj: &Object) {
     register_closure(obj, "record_f64", record_f64);
 
     let record_memory = Closure::wrap(Box::new(
-        move |is_load: i32, addr_slot: u32, byte_count: i32, value_slot: u32| {
-            record_memory_access(is_load, addr_slot, byte_count as u8, value_slot)
+        move |is_load: i32,
+              mem_idx: u32,
+              addr_slot: u32,
+              offset: i64,
+              byte_count: i32,
+              value_slot: u32| {
+            record_memory_access(
+                is_load,
+                mem_idx,
+                addr_slot,
+                offset as u64,
+                byte_count as u8,
+                value_slot,
+            )
         },
-    ) as Box<dyn Fn(i32, u32, i32, u32)>);
+    ) as Box<dyn Fn(i32, u32, u32, i64, i32, u32)>);
     register_closure(obj, "record_memory", record_memory);
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -11,7 +11,7 @@
 
 use crate::{
     dom_canvas::{Action, DomCanvas},
-    utils::{FmtError, MemoryOp, StaticMemoryAccess},
+    utils::{FmtError, StaticMemoryAccess},
 };
 use anyhow::{Context, Result, bail};
 use js_sys::{Object, Reflect, WebAssembly::RuntimeError};
@@ -31,12 +31,7 @@ thread_local! {
     static STEPS: Box<[CodillonCell<ExecutionStep>]> = (0..MAX_STEP_COUNT)
                 .map(|_| CodillonCell::new(ExecutionStep::default()))
                 .collect();
-    static MEMORY_OPS: CodillonCell<Vec<StaticMemoryAccess>> = CodillonCell::new(Vec::new());
     static INSTRUMENTATION_IMPORTS: Object = make_imports().expect("instrumentation");
-}
-
-pub fn set_memory_ops(ops: Vec<StaticMemoryAccess>) {
-    MEMORY_OPS.with(|cell| cell.set(ops));
 }
 
 // When a user Wasm module gets close to stack exhaustion, the browser can trap at any point
@@ -207,15 +202,6 @@ fn error_string() -> Option<String> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-pub struct MemoryAccess {
-    pub op: MemoryOp,
-    pub mem_idx: u32,     // memory index
-    pub addr: u64,        // concrete addr = addr operand + offset
-    pub byte_count: u8,   // can be 1, 2, 4, or 8
-    pub value: WasmValue, // actual load/store value
-}
-
 #[derive(Default, Debug)]
 struct ExecutionStep {
     line_num: u32,
@@ -240,6 +226,7 @@ pub struct ExecutionState {
     pub step: usize,
     pub slots: Vec<Option<WasmValue>>,
     pub status: Option<(usize, TerminationType, Option<String>)>,
+    pub memory_ops: Vec<StaticMemoryAccess>,
 }
 
 impl ExecutionState {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -11,7 +11,7 @@
 
 use crate::{
     dom_canvas::{Action, DomCanvas},
-    utils::FmtError,
+    utils::{FmtError, MemoryOp, StaticMemoryAccess},
 };
 use anyhow::{Context, Result, bail};
 use js_sys::{Object, Reflect, WebAssembly::RuntimeError};
@@ -31,7 +31,12 @@ thread_local! {
     static STEPS: Box<[CodillonCell<ExecutionStep>]> = (0..MAX_STEP_COUNT)
                 .map(|_| CodillonCell::new(ExecutionStep::default()))
                 .collect();
+    static MEMORY_OPS: CodillonCell<Vec<StaticMemoryAccess>> = CodillonCell::new(Vec::new());
     static INSTRUMENTATION_IMPORTS: Object = make_imports().expect("instrumentation");
+}
+
+pub fn set_memory_ops(ops: Vec<StaticMemoryAccess>) {
+    MEMORY_OPS.with(|cell| cell.set(ops));
 }
 
 // When a user Wasm module gets close to stack exhaustion, the browser can trap at any point
@@ -203,12 +208,6 @@ fn error_string() -> Option<String> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum MemoryOp {
-    Load,
-    Store,
-}
-
-#[derive(Debug, Copy, Clone)]
 pub struct MemoryAccess {
     pub op: MemoryOp,
     pub mem_idx: u32,     // memory index
@@ -222,9 +221,9 @@ struct ExecutionStep {
     line_num: u32,
     slot_assignments: SmallVec<[(u32, WasmValue); 1]>, // slot idx, value (SmallVec stores in-line if <=1 result)
     graphics_op: Option<Action>,
-    memory_access: Option<MemoryAccess>,
-    // XXX todo: clear any func/frame on entry
-    // XXX todo: save any func on call/call_indirect, restore after
+    memory_access: Option<u32>, // index into MEMORY_OPS
+                                // XXX todo: clear any func/frame on entry
+                                // XXX todo: save any func on call/call_indirect, restore after
 }
 
 impl ExecutionStep {
@@ -241,7 +240,6 @@ pub struct ExecutionState {
     pub step: usize,
     pub slots: Vec<Option<WasmValue>>,
     pub status: Option<(usize, TerminationType, Option<String>)>,
-    pub memory_access: Option<MemoryAccess>,
 }
 
 impl ExecutionState {
@@ -283,17 +281,6 @@ impl ExecutionState {
             },
             error_string(),
         ));
-
-        self.memory_access = with_completed_step(target_step, |s| s.memory_access);
-        if let Some(ma) = &self.memory_access {
-            web_sys::console::log_1(
-                &format!(
-                    "{:?} mem[{}] addr={} bytes={} value={:?}",
-                    ma.op, ma.mem_idx, ma.addr, ma.byte_count, ma.value
-                )
-                .into(),
-            );
-        }
     }
 }
 
@@ -401,34 +388,8 @@ fn create_graphics_helpers(draw: &Object) {
     register_closure(draw, "set_radius", set_radius);
 }
 
-fn record_memory_access(
-    is_load: i32,
-    mem_idx: u32,
-    addr: u64,
-    byte_count: u8,
-    value_bits: i64,
-    is_float: i32,
-) {
-    let value = match (byte_count, is_float) {
-        (1 | 2 | 4, 0) => WasmValue::I32(value_bits as i32),
-        (8, 0) => WasmValue::I64(value_bits),
-        (4, 1) => WasmValue::F32(f32::from_bits(value_bits as u32)),
-        (8, 1) => WasmValue::F64(f64::from_bits(value_bits as u64)),
-        _ => unreachable!(),
-    };
-    with_current_step_mut(|step| {
-        step.memory_access = Some(MemoryAccess {
-            op: if is_load != 0 {
-                MemoryOp::Load
-            } else {
-                MemoryOp::Store
-            },
-            mem_idx,
-            addr,
-            byte_count,
-            value,
-        });
-    });
+fn record_memory_access(index: u32) {
+    with_current_step_mut(|step| step.memory_access = Some(index));
 }
 
 fn create_closure_record_operations(obj: &Object) {
@@ -455,23 +416,9 @@ fn create_closure_record_operations(obj: &Object) {
     );
     register_closure(obj, "record_f64", record_f64);
 
-    let record_memory = Closure::wrap(Box::new(
-        move |is_load: i32,
-              mem_idx: u32,
-              addr: i64,
-              byte_count: i32,
-              value_bits: i64,
-              is_float: i32| {
-            record_memory_access(
-                is_load,
-                mem_idx,
-                addr as u64,
-                byte_count as u8,
-                value_bits,
-                is_float,
-            )
-        },
-    ) as Box<dyn Fn(i32, u32, i64, i32, i64, i32)>);
+    let record_memory = Closure::wrap(
+        Box::new(move |index: i32| record_memory_access(index as u32)) as Box<dyn Fn(i32)>,
+    );
     register_closure(obj, "record_memory", record_memory);
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -202,13 +202,28 @@ fn error_string() -> Option<String> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum MemoryOp {
+    Load,
+    Store,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct MemoryAccess {
+    pub op: MemoryOp,
+    pub addr_slot: u32,  // slot idx for address
+    pub byte_count: u8,  // can be 1, 2, 4, or 8
+    pub value_slot: u32, // slot idx for value
+}
+
 #[derive(Default, Debug)]
 struct ExecutionStep {
     line_num: u32,
     slot_assignments: SmallVec<[(u32, WasmValue); 1]>, // slot idx, value (SmallVec stores in-line if <=1 result)
-    graphics_op: Option<Action>,                       // XXX todo: memory
-                                                       // XXX todo: clear any func/frame on entry
-                                                       // XXX todo: save any func on call/call_indirect, restore after
+    graphics_op: Option<Action>,
+    memory_access: Option<MemoryAccess>,
+    // XXX todo: clear any func/frame on entry
+    // XXX todo: save any func on call/call_indirect, restore after
 }
 
 impl ExecutionStep {
@@ -216,6 +231,7 @@ impl ExecutionStep {
         self.line_num = 0;
         self.slot_assignments.clear();
         self.graphics_op = None;
+        self.memory_access = None;
     }
 }
 
@@ -372,6 +388,21 @@ fn create_graphics_helpers(draw: &Object) {
     register_closure(draw, "set_radius", set_radius);
 }
 
+fn record_memory_access(is_load: i32, addr_slot: u32, byte_count: u8, value_slot: u32) {
+    with_current_step_mut(|step| {
+        step.memory_access = Some(MemoryAccess {
+            op: if is_load != 0 {
+                MemoryOp::Load
+            } else {
+                MemoryOp::Store
+            },
+            addr_slot,
+            byte_count,
+            value_slot,
+        });
+    });
+}
+
 fn create_closure_record_operations(obj: &Object) {
     let record = |value: WasmValue, slot: u32| {
         with_current_step_mut(|step| step.slot_assignments.push((slot, value)))
@@ -395,6 +426,13 @@ fn create_closure_record_operations(obj: &Object) {
         Box::new(move |value: f64, slot: u32| record(value.into(), slot)) as Box<dyn Fn(f64, u32)>,
     );
     register_closure(obj, "record_f64", record_f64);
+
+    let record_memory = Closure::wrap(Box::new(
+        move |is_load: i32, addr_slot: u32, byte_count: i32, value_slot: u32| {
+            record_memory_access(is_load, addr_slot, byte_count as u8, value_slot)
+        },
+    ) as Box<dyn Fn(i32, u32, i32, u32)>);
+    register_closure(obj, "record_memory", record_memory);
 }
 
 pub async fn run_binary(binary: &[u8]) -> Result<()> {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -201,13 +201,28 @@ fn error_string() -> Option<String> {
     }
 }
 
+#[derive(Debug, Copy, Clone)]
+pub enum MemoryOp {
+    Load,
+    Store,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct MemoryAccess {
+    pub op: MemoryOp,
+    pub addr_slot: u32,  // slot idx for address
+    pub byte_count: u8,  // can be 1, 2, 4, or 8
+    pub value_slot: u32, // slot idx for value
+}
+
 #[derive(Default, Debug)]
 struct ExecutionStep {
     line_num: u32,
     slot_assignments: Vec<(u32, WasmValue)>, // slot idx, value
-    graphics_ops: Vec<Action>,               // XXX todo: memory
-                                             // XXX todo: clear any func/frame on entry
-                                             // XXX todo: save any func on call/call_indirect, restore after
+    graphics_ops: Vec<Action>,
+    memory_access: Option<MemoryAccess>,
+    // XXX todo: clear any func/frame on entry
+    // XXX todo: save any func on call/call_indirect, restore after
 }
 
 impl ExecutionStep {
@@ -215,6 +230,7 @@ impl ExecutionStep {
         self.line_num = 0;
         self.slot_assignments.clear();
         self.graphics_ops.clear();
+        self.memory_access = None;
     }
 }
 
@@ -364,6 +380,21 @@ fn create_graphics_helpers(draw: &Object) {
     register_closure(draw, "set_radius", set_radius);
 }
 
+fn record_memory_access(is_load: i32, addr_slot: u32, byte_count: u8, value_slot: u32) {
+    with_current_step_mut(|step| {
+        step.memory_access = Some(MemoryAccess {
+            op: if is_load != 0 {
+                MemoryOp::Load
+            } else {
+                MemoryOp::Store
+            },
+            addr_slot,
+            byte_count,
+            value_slot,
+        });
+    });
+}
+
 fn create_closure_record_operations(obj: &Object) {
     let record = |value: WasmValue, slot: u32| {
         with_current_step_mut(|step| step.slot_assignments.push((slot, value)))
@@ -387,6 +418,13 @@ fn create_closure_record_operations(obj: &Object) {
         Box::new(move |value: f64, slot: u32| record(value.into(), slot)) as Box<dyn Fn(f64, u32)>,
     );
     register_closure(obj, "record_f64", record_f64);
+
+    let record_memory = Closure::wrap(Box::new(
+        move |is_load: i32, addr_slot: u32, byte_count: i32, value_slot: u32| {
+            record_memory_access(is_load, addr_slot, byte_count as u8, value_slot)
+        },
+    ) as Box<dyn Fn(i32, u32, i32, u32)>);
+    register_closure(obj, "record_memory", record_memory);
 }
 
 pub async fn run_binary(binary: &[u8]) -> Result<()> {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -211,11 +211,10 @@ pub enum MemoryOp {
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryAccess {
     pub op: MemoryOp,
-    pub mem_idx: u32,    // memory index
-    pub addr_slot: u32,  // slot idx for address
-    pub offset: u64,     // concrete addr = slots[addr_slot] + offset
-    pub byte_count: u8,  // can be 1, 2, 4, or 8
-    pub value_slot: u32, // slot idx for value (only for store)
+    pub mem_idx: u32,     // memory index
+    pub addr: u64,        // concrete addr = addr operand + offset
+    pub byte_count: u8,   // can be 1, 2, 4, or 8
+    pub value: WasmValue, // actual load/store value
 }
 
 #[derive(Default, Debug)]
@@ -242,6 +241,7 @@ pub struct ExecutionState {
     pub step: usize,
     pub slots: Vec<Option<WasmValue>>,
     pub status: Option<(usize, TerminationType, Option<String>)>,
+    pub memory_access: Option<MemoryAccess>,
 }
 
 impl ExecutionState {
@@ -283,6 +283,17 @@ impl ExecutionState {
             },
             error_string(),
         ));
+
+        self.memory_access = with_completed_step(target_step, |s| s.memory_access);
+        if let Some(ma) = &self.memory_access {
+            web_sys::console::log_1(
+                &format!(
+                    "{:?} mem[{}] addr={} bytes={} value={:?}",
+                    ma.op, ma.mem_idx, ma.addr, ma.byte_count, ma.value
+                )
+                .into(),
+            );
+        }
     }
 }
 
@@ -393,11 +404,18 @@ fn create_graphics_helpers(draw: &Object) {
 fn record_memory_access(
     is_load: i32,
     mem_idx: u32,
-    addr_slot: u32,
-    offset: u64,
+    addr: u64,
     byte_count: u8,
-    value_slot: u32,
+    value_bits: i64,
+    is_float: i32,
 ) {
+    let value = match (byte_count, is_float) {
+        (1 | 2 | 4, 0) => WasmValue::I32(value_bits as i32),
+        (8, 0) => WasmValue::I64(value_bits),
+        (4, 1) => WasmValue::F32(f32::from_bits(value_bits as u32)),
+        (8, 1) => WasmValue::F64(f64::from_bits(value_bits as u64)),
+        _ => unreachable!(),
+    };
     with_current_step_mut(|step| {
         step.memory_access = Some(MemoryAccess {
             op: if is_load != 0 {
@@ -406,10 +424,9 @@ fn record_memory_access(
                 MemoryOp::Store
             },
             mem_idx,
-            addr_slot,
-            offset,
+            addr,
             byte_count,
-            value_slot,
+            value,
         });
     });
 }
@@ -441,20 +458,20 @@ fn create_closure_record_operations(obj: &Object) {
     let record_memory = Closure::wrap(Box::new(
         move |is_load: i32,
               mem_idx: u32,
-              addr_slot: u32,
-              offset: i64,
+              addr: i64,
               byte_count: i32,
-              value_slot: u32| {
+              value_bits: i64,
+              is_float: i32| {
             record_memory_access(
                 is_load,
                 mem_idx,
-                addr_slot,
-                offset as u64,
+                addr as u64,
                 byte_count as u8,
-                value_slot,
+                value_bits,
+                is_float,
             )
         },
-    ) as Box<dyn Fn(i32, u32, u32, i64, i32, u32)>);
+    ) as Box<dyn Fn(i32, u32, i64, i32, i64, i32)>);
     register_closure(obj, "record_memory", record_memory);
 }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -782,7 +782,7 @@ impl Editor {
         let (instrumented_binary_owned, memory_ops) =
             validized.build_instrumented_binary(&types)?;
         let instrumented_binary = &instrumented_binary_owned;
-        crate::debug::set_memory_ops(memory_ops);
+        self.execution_state.memory_ops = memory_ops;
         let instrumented_binary_hash = Self::hash_binary(instrumented_binary);
         if self.previous_instrumented_binary_hash != instrumented_binary_hash {
             self.version += 1;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -779,7 +779,10 @@ impl Editor {
         self.update_displayed_types(&validized, &types)?;
 
         // instrumentation
-        let instrumented_binary = &validized.build_instrumented_binary(&types)?;
+        let (instrumented_binary_owned, memory_ops) =
+            validized.build_instrumented_binary(&types)?;
+        let instrumented_binary = &instrumented_binary_owned;
+        crate::debug::set_memory_ops(memory_ops);
         let instrumented_binary_hash = Self::hash_binary(instrumented_binary);
         if self.previous_instrumented_binary_hash != instrumented_binary_hash {
             self.version += 1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2483,6 +2483,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
+  (type (func (param i32 i32 i32 i32)))
   (type (func (param i32)))
 "#;
     const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 2)))
@@ -2491,12 +2492,13 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f32" (func (type 5)))
   (import "codillon_debug" "record_i64" (func (type 6)))
   (import "codillon_debug" "record_f64" (func (type 7)))
+  (import "codillon_debug" "record_memory" (func (type 8)))
 "#;
 
-    const EXPECTED_MAIN: &str = r#"  (export "main" (func 6))
+    const EXPECTED_MAIN: &str = r#"  (export "main" (func 7))
 "#;
 
-    const EXPECTED_STEP: &str = r#"  (func (type 8) (param i32)
+    const EXPECTED_STEP: &str = r#"  (func (type 9) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -2520,9 +2522,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 0
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2539,9 +2541,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2558,9 +2560,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 1
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2577,9 +2579,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2598,20 +2600,20 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
-    i32.const 0
-    call 7
-    i64.const 17
+    call 8
     i32.const 0
     call 8
+    i64.const 17
+    i32.const 0
+    call 9
     i32.const 1
-    call 7
+    call 8
     drop
     i32.const 2
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i64 i32) (result i64)
+                + r#"  (func (type 10) (param i64 i32) (result i64)
     local.get 0
     local.get 1
     call 4
@@ -2624,15 +2626,15 @@ pub(crate) mod tests {
 
         // well-formed block
         const JUST_BLOCK_END: &str = r#"    i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     block ;; label = @1
       i32.const 2
-      call 7
+      call 8
     end
     i32.const 3
-    call 7
+    call 8
   )
 "#;
         {
@@ -2685,28 +2687,28 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 137
     i32.const 0
-    call 8
+    call 9
     i32.const 2
-    call 7
+    call 8
     i32.const 2
     call 1
     unreachable
     i32.add
     i32.const 3
-    call 8
+    call 9
     i32.const 3
-    call 7
+    call 8
     drop
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i32 i32) (result i32)
+                + r#"  (func (type 10) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -2732,12 +2734,12 @@ pub(crate) mod tests {
                 + EXPECTED_TYPES
                 + EXPECTED_IMPORTS
                 + r#"  (import "codillon_debug" "func_placeholder" (func (type 1)))
-  (export "main" (func 7))
+  (export "main" (func 8))
   (func (type 0)
     i32.const 6
-    call 8
+    call 9
     i32.const 6
-    call 8
+    call 9
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2782,21 +2784,21 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     block ;; label = @1
       i32.const 2
-      call 7
+      call 8
       loop ;; label = @2
         i32.const 4
-        call 7
+        call 8
       end
       i32.const 5
-      call 7
+      call 8
     end
     i32.const 6
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2815,15 +2817,15 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 1
     call 1
     unreachable
     nop
     i32.const 2
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2845,21 +2847,21 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 1
-    call 7
+    call 8
     i32.const 2
-    call 7
+    call 8
     i32.const 2
     call 1
     unreachable
     nop
     i32.const 3
-    call 7
+    call 8
     i32.const 3
     call 1
     unreachable
     drop
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2880,26 +2882,26 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 0
-    call 7
+    call 8
     loop ;; label = @1
       i32.const 1
-      call 7
+      call 8
       i32.const 5
       i32.const 0
-      call 8
+      call 9
       i32.const 2
-      call 7
+      call 8
       br 0 (;@1;)
       i32.const 3
-      call 7
+      call 8
     end
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i32 i32) (result i32)
+                + r#"  (func (type 10) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -2924,20 +2926,20 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 4
     i32.const 0
-    call 8
+    call 9
     i32.const 2
-    call 7
+    call 8
     i32.const 2
     call 1
     unreachable
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i32 i32) (result i32)
+                + r#"  (func (type 10) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -2969,6 +2971,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
+  (type (func (param i32 i32 i32 i32)))
   (type (func (param i32)))
   (type (func (param i32 i32 i32 i32) (result i32 i32)))
   (type (func (param i32 i32) (result i32)))
@@ -2978,49 +2981,50 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f32" (func (type 6)))
   (import "codillon_debug" "record_i64" (func (type 7)))
   (import "codillon_debug" "record_f64" (func (type 8)))
-  (export "main" (func 6))
+  (import "codillon_debug" "record_memory" (func (type 9)))
+  (export "main" (func 7))
   (func (type 0)
     i32.const 0
-    call 8
-    i32.const 1
-    call 8
-    call 7
-    i32.const 1
-    call 8
-    i32.const 0
+    call 9
     i32.const 1
     call 9
-    i32.const 2
     call 8
+    i32.const 1
+    call 9
+    i32.const 0
+    i32.const 1
+    call 10
+    i32.const 2
+    call 9
     i32.add
     i32.const 2
-    call 10
+    call 11
     i32.const 3
-    call 8
+    call 9
     i32.const 3
     call 1
     unreachable
   )
   (func (type 1) (result i32 i32)
     i32.const 4
-    call 8
+    call 9
     i32.const 5
-    call 8
+    call 9
     i32.const 9
     i32.const 3
-    call 10
-    i32.const 6
-    call 8
-    i32.const 10
-    i32.const 4
-    call 10
-    i32.const 7
-    call 8
-    i32.const 5
+    call 11
     i32.const 6
     call 9
+    i32.const 10
+    i32.const 4
+    call 11
+    i32.const 7
+    call 9
+    i32.const 5
+    i32.const 6
+    call 10
   )
-  (func (type 9) (param i32)
+  (func (type 10) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -3028,7 +3032,7 @@ pub(crate) mod tests {
       unreachable
     end
   )
-  (func (type 10) (param i32 i32 i32 i32) (result i32 i32)
+  (func (type 11) (param i32 i32 i32 i32) (result i32 i32)
     local.get 0
     local.get 2
     call 2
@@ -3038,7 +3042,7 @@ pub(crate) mod tests {
     local.get 0
     local.get 1
   )
-  (func (type 11) (param i32 i32) (result i32)
+  (func (type 12) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3076,9 +3080,9 @@ pub(crate) mod tests {
     i32.const 3
     call 5
     i32.const 0
-    call 7
+    call 8
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3103,6 +3107,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
+  (type (func (param i32 i32 i32 i32)))
   (type (func (param i32)))
   (type (func (param i32 i32) (result i32)))
   (import "codillon_debug" "record_step" (func (type 3)))
@@ -3111,28 +3116,29 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f32" (func (type 6)))
   (import "codillon_debug" "record_i64" (func (type 7)))
   (import "codillon_debug" "record_f64" (func (type 8)))
-  (export "main" (func 6))
+  (import "codillon_debug" "record_memory" (func (type 9)))
+  (export "main" (func 7))
   (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 1
     call 1
     unreachable
     block (type 1) (param i32) ;; label = @1
       i32.const 1
-      call 8
+      call 9
       i32.const 2
-      call 7
+      call 8
       i32.const 2
       call 1
       unreachable
     end
     i32.const 3
-    call 7
+    call 8
   )
-  (func (type 9) (param i32)
+  (func (type 10) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -3140,7 +3146,7 @@ pub(crate) mod tests {
       unreachable
     end
   )
-  (func (type 10) (param i32 i32) (result i32)
+  (func (type 11) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3162,17 +3168,17 @@ pub(crate) mod tests {
                 + EXPECTED_TYPES
                 + EXPECTED_IMPORTS
                 + r#"  (import "codillon_debug" "func_placeholder" (func (type 1)))
-  (export "main" (func 7))
+  (export "main" (func 8))
   (func (type 0)
     i32.const 1
-    call 8
+    call 9
     i32.const 2
-    call 8
-    call 6
+    call 9
+    call 7
     i32.const 2
-    call 8
+    call 9
     i32.const 3
-    call 8
+    call 9
   )
 "# + EXPECTED_STEP
                 + ")\n";

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,11 +75,11 @@ pub enum MemoryOp {
 #[derive(Debug, Copy, Clone)]
 pub struct StaticMemoryAccess {
     pub op: MemoryOp,
-    pub mem_idx: u32,    // memory index
-    pub addr_slot: u32,  // slot idx for address
-    pub offset: u64,     // concrete addr = slots[addr_slot] + offset
-    pub byte_count: u8,  // can be 1, 2, 4, or 8
-    pub value_slot: u32, // slot idx for value
+    pub mem_idx: u32,      // memory index
+    pub addr_slot: usize,  // slot idx for address
+    pub offset: u64,       // concrete addr = slots[addr_slot] + offset
+    pub byte_count: u8,    // can be 1, 2, 4, or 8
+    pub value_slot: usize, // slot idx for value
 }
 
 #[derive(PartialEq, Eq)]
@@ -1347,8 +1347,8 @@ impl<'a> ValidModule<'a> {
             let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
             let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
             let (addr_slot, value_slot) = match (is_load, input0, input1) {
-                (true, Some(SlotUse(a)), _) => (*a as u32, op_type.outputs[0].0 as u32),
-                (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a as u32, *v as u32),
+                (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
+                (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
                 _ => return, /* don't record memory footprint in unreachable code */
             };
             // Build static lookup table for memory ops

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,15 +60,15 @@ impl InstrImports {
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
         // 5: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
-        // 6: (is_load: i32, mem_idx: i32, addr_slot: i32, offset: i64,
-        //     byte_count: i32, value_slot: i32) -> ()
+        // 6: (is_load: i32, mem_idx: i32, addr: i64, byte_count: i32,
+        //     value_bits: i64, is_float: i32) -> ()
         (
             &[
                 EncoderValType::I32,
                 EncoderValType::I32,
-                EncoderValType::I32,
                 EncoderValType::I64,
                 EncoderValType::I32,
+                EncoderValType::I64,
                 EncoderValType::I32,
             ],
             &[],
@@ -1119,10 +1119,11 @@ impl<'a> ValidModule<'a> {
             let mut bounds_check_to_func_idx = IndexMap::new();
             for func in &self.functions {
                 for op in &func.operators {
-                    if let Some((mem_idx, _, _, ty)) = bounds_check_info(&op.inner.op)
+                    if let Some((mem_idx, _, _, is_load, val_type)) = memory_op_info(&op.inner.op)
                         && shadow_memory_indices.contains(&(mem_idx as usize))
-                        && !bounds_check_to_func_idx.contains_key(&ty)
+                        && !bounds_check_to_func_idx.contains_key(&(!is_load).then_some(val_type))
                     {
+                        let ty = (!is_load).then_some(val_type);
                         let (params, results) = match ty {
                             None => (
                                 vec![EncoderValType::I32, EncoderValType::I64], // offset, limit
@@ -1280,13 +1281,16 @@ impl<'a> ValidModule<'a> {
         let orig_function = &self.functions[func_idx];
         let typed_function = &types.funcs[func_idx];
         let num_instr_imports = InstrImports::TYPE_INDICES.len() as u32; // also idx of step function
-        let mut new_function = wasm_encoder::Function::new_with_locals_types(
-            orig_function
-                .locals
-                .iter()
-                .map(|ty| RoundtripReencoder.val_type(ty.inner).fmt_err())
-                .collect::<Result<Vec<_>>>()?,
-        );
+        let mut locals: Vec<EncoderValType> = orig_function
+            .locals
+            .iter()
+            .map(|ty| RoundtripReencoder.val_type(ty.inner).fmt_err())
+            .collect::<Result<Vec<_>>>()?;
+        locals.push(EncoderValType::I32); // tmp_addr
+        locals.push(EncoderValType::I64); // tmp_bits
+        let mut new_function = wasm_encoder::Function::new_with_locals_types(locals);
+        let tmp_addr = (typed_function.params.len() + orig_function.locals.len()) as u32;
+        let tmp_bits = tmp_addr + 1;
 
         let transparent_record_results =
             |f: &mut wasm_encoder::Function, results: &Vec<SlotUse>| {
@@ -1329,22 +1333,38 @@ impl<'a> ValidModule<'a> {
                              mem_idx: u32,
                              offset: u64,
                              byte_count: u8,
-                             op_type: &OperatorType| {
-            let is_load = !op_type.outputs.is_empty();
-            let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
-            let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
-            let (addr, value) = match (is_load, input0, input1) {
-                (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
-                (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
-                _ => return, /* don't record memory footprint in unreachable code */
-            };
+                             is_load: bool,
+                             val_type: EncoderValType,
+                             op: &wasm_encoder::Instruction<'_>| {
+            let is_float = matches!(val_type, EncoderValType::F32 | EncoderValType::F64) as i32;
+            if is_load {
+                // stack: [..., addr]
+                f.instruction(&LocalTee(tmp_addr)); // save addr, keep on stack
+                f.instruction(op); // pre-read: stack: [..., value]
+                emit_to_bits(f, val_type); // stack: [..., bits]
+                f.instruction(&LocalSet(tmp_bits)); // stack: [...]
+            } else {
+                // stack: [..., addr, value]
+                emit_to_bits(f, val_type); // stack: [..., addr, bits]
+                f.instruction(&LocalSet(tmp_bits)); // stack: [..., addr]
+                f.instruction(&LocalTee(tmp_addr)); // stack: [..., addr]
+            }
             f.instruction(&I32Const(is_load as i32));
             f.instruction(&I32Const(mem_idx as i32));
-            f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
+            f.instruction(&LocalGet(tmp_addr));
+            f.instruction(&I64ExtendI32U);
             f.instruction(&I64Const(offset as i64));
+            f.instruction(&I64Add); // byte_addr = addr_operand + offset
             f.instruction(&I32Const(byte_count as i32));
-            f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
+            f.instruction(&LocalGet(tmp_bits));
+            f.instruction(&I32Const(is_float));
             f.instruction(&Call(InstrImports::RecordMemory as u32));
+            // restore stack for actual op:
+            f.instruction(&LocalGet(tmp_addr));
+            if !is_load {
+                f.instruction(&LocalGet(tmp_bits));
+                emit_from_bits(f, val_type); // restore value for store
+            }
         };
 
         let step_debug = |f: &mut wasm_encoder::Function, line_number: usize| {
@@ -1410,8 +1430,8 @@ impl<'a> ValidModule<'a> {
             }
 
             // bounds checking for load and store operations for memories with pagesize 1
-            if let Some((mem_idx, offset, width, ty)) =
-                bounds_check_info(&codillon_operator.inner.op)
+            if let Some((mem_idx, offset, width, is_load, val_type)) =
+                memory_op_info(&codillon_operator.inner.op)
                 && let Some(shadow_pos) = shadow_memory_indices
                     .iter()
                     .position(|&i| i == mem_idx as usize)
@@ -1421,7 +1441,25 @@ impl<'a> ValidModule<'a> {
                 new_function.instruction(&GlobalGet(shadow_global_idx));
                 new_function.instruction(&I64Const(total_offset));
                 new_function.instruction(&I64Sub); // limit = size - (offset + width)
-                new_function.instruction(&Call(bounds_check_to_func_idx[&ty]));
+                new_function.instruction(&Call(
+                    bounds_check_to_func_idx[&(!is_load).then_some(val_type)],
+                ));
+            }
+
+            // dynamic memory recording for all memory ops
+            if let Some((mem_idx, offset, width, is_load, val_type)) =
+                memory_op_info(&codillon_operator.inner.op)
+                && !codillon_operator.inner.untyped
+            {
+                memory_record(
+                    &mut new_function,
+                    mem_idx,
+                    offset,
+                    width,
+                    is_load,
+                    val_type,
+                    &op,
+                );
             }
 
             if i + 1 == orig_function.operators.len() {
@@ -1471,25 +1509,6 @@ impl<'a> ValidModule<'a> {
                         .nth(idx as usize)
                         .expect("valid local idx");
                     primitive_record(&mut new_function, local_type)?;
-                }
-
-                I32Load8S(m) | I32Load8U(m) | I64Load8S(m) | I64Load8U(m) | I32Store8(m)
-                | I64Store8(m) => {
-                    memory_record(&mut new_function, m.memory_index, m.offset, 1, op_type)
-                }
-
-                I32Load16S(m) | I32Load16U(m) | I64Load16S(m) | I64Load16U(m) | I32Store16(m)
-                | I64Store16(m) => {
-                    memory_record(&mut new_function, m.memory_index, m.offset, 2, op_type)
-                }
-
-                I32Load(m) | F32Load(m) | I32Store(m) | F32Store(m) | I64Load32S(m)
-                | I64Load32U(m) | I64Store32(m) => {
-                    memory_record(&mut new_function, m.memory_index, m.offset, 4, op_type)
-                }
-
-                I64Load(m) | F64Load(m) | I64Store(m) | F64Store(m) => {
-                    memory_record(&mut new_function, m.memory_index, m.offset, 8, op_type)
                 }
                 _ => {}
             }
@@ -1558,31 +1577,81 @@ impl<'a> ValidModule<'a> {
     }
 }
 
-fn bounds_check_info(op: &Operator<'_>) -> Option<(u32, u64, i32, Option<EncoderValType>)> {
+/// Returns (mem_idx, offset, width, is_load, val_type) for a load/store instruction
+fn memory_op_info(op: &Operator<'_>) -> Option<(u32, u64, u8, bool, EncoderValType)> {
     use Operator::*;
     match op {
-        I32Load8S { memarg }
-        | I32Load8U { memarg }
-        | I64Load8S { memarg }
-        | I64Load8U { memarg } => Some((memarg.memory, memarg.offset, 1, None)),
-        I32Load16S { memarg }
-        | I32Load16U { memarg }
-        | I64Load16S { memarg }
-        | I64Load16U { memarg } => Some((memarg.memory, memarg.offset, 2, None)),
-        I32Load { memarg } | F32Load { memarg } | I64Load32S { memarg } | I64Load32U { memarg } => {
-            Some((memarg.memory, memarg.offset, 4, None))
+        I32Load8S { memarg } | I32Load8U { memarg } => {
+            Some((memarg.memory, memarg.offset, 1, true, EncoderValType::I32))
         }
-        I64Load { memarg } | F64Load { memarg } => Some((memarg.memory, memarg.offset, 8, None)),
-        I32Store8 { memarg } => Some((memarg.memory, memarg.offset, 1, Some(EncoderValType::I32))),
-        I32Store16 { memarg } => Some((memarg.memory, memarg.offset, 2, Some(EncoderValType::I32))),
-        I32Store { memarg } => Some((memarg.memory, memarg.offset, 4, Some(EncoderValType::I32))),
-        I64Store8 { memarg } => Some((memarg.memory, memarg.offset, 1, Some(EncoderValType::I64))),
-        I64Store16 { memarg } => Some((memarg.memory, memarg.offset, 2, Some(EncoderValType::I64))),
-        I64Store32 { memarg } => Some((memarg.memory, memarg.offset, 4, Some(EncoderValType::I64))),
-        I64Store { memarg } => Some((memarg.memory, memarg.offset, 8, Some(EncoderValType::I64))),
-        F32Store { memarg } => Some((memarg.memory, memarg.offset, 4, Some(EncoderValType::F32))),
-        F64Store { memarg } => Some((memarg.memory, memarg.offset, 8, Some(EncoderValType::F64))),
+        I64Load8S { memarg } | I64Load8U { memarg } => {
+            Some((memarg.memory, memarg.offset, 1, true, EncoderValType::I64))
+        }
+        I32Load16S { memarg } | I32Load16U { memarg } => {
+            Some((memarg.memory, memarg.offset, 2, true, EncoderValType::I32))
+        }
+        I64Load16S { memarg } | I64Load16U { memarg } => {
+            Some((memarg.memory, memarg.offset, 2, true, EncoderValType::I64))
+        }
+        I32Load { memarg } => Some((memarg.memory, memarg.offset, 4, true, EncoderValType::I32)),
+        F32Load { memarg } => Some((memarg.memory, memarg.offset, 4, true, EncoderValType::F32)),
+        I64Load32S { memarg } | I64Load32U { memarg } => {
+            Some((memarg.memory, memarg.offset, 4, true, EncoderValType::I64))
+        }
+        I64Load { memarg } => Some((memarg.memory, memarg.offset, 8, true, EncoderValType::I64)),
+        F64Load { memarg } => Some((memarg.memory, memarg.offset, 8, true, EncoderValType::F64)),
+        I32Store8 { memarg } => Some((memarg.memory, memarg.offset, 1, false, EncoderValType::I32)),
+        I64Store8 { memarg } => Some((memarg.memory, memarg.offset, 1, false, EncoderValType::I64)),
+        I32Store16 { memarg } => {
+            Some((memarg.memory, memarg.offset, 2, false, EncoderValType::I32))
+        }
+        I64Store16 { memarg } => {
+            Some((memarg.memory, memarg.offset, 2, false, EncoderValType::I64))
+        }
+        I32Store { memarg } => Some((memarg.memory, memarg.offset, 4, false, EncoderValType::I32)),
+        F32Store { memarg } => Some((memarg.memory, memarg.offset, 4, false, EncoderValType::F32)),
+        I64Store32 { memarg } => {
+            Some((memarg.memory, memarg.offset, 4, false, EncoderValType::I64))
+        }
+        I64Store { memarg } => Some((memarg.memory, memarg.offset, 8, false, EncoderValType::I64)),
+        F64Store { memarg } => Some((memarg.memory, memarg.offset, 8, false, EncoderValType::F64)),
         _ => None,
+    }
+}
+
+fn emit_to_bits(f: &mut wasm_encoder::Function, val_type: EncoderValType) {
+    use wasm_encoder::Instruction::*;
+    match val_type {
+        EncoderValType::I32 => {
+            f.instruction(&I64ExtendI32U);
+        }
+        EncoderValType::I64 => {}
+        EncoderValType::F32 => {
+            f.instruction(&I32ReinterpretF32);
+            f.instruction(&I64ExtendI32U);
+        }
+        EncoderValType::F64 => {
+            f.instruction(&I64ReinterpretF64);
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn emit_from_bits(f: &mut wasm_encoder::Function, val_type: EncoderValType) {
+    use wasm_encoder::Instruction::*;
+    match val_type {
+        EncoderValType::I32 => {
+            f.instruction(&I32WrapI64);
+        }
+        EncoderValType::I64 => {}
+        EncoderValType::F32 => {
+            f.instruction(&I32WrapI64);
+            f.instruction(&F32ReinterpretI32);
+        }
+        EncoderValType::F64 => {
+            f.instruction(&F64ReinterpretI64);
+        }
+        _ => unreachable!(),
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,20 +60,26 @@ impl InstrImports {
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
         // 5: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
-        // 6: (is_load: i32, mem_idx: i32, addr: i64, byte_count: i32,
-        //     value_bits: i64, is_float: i32) -> ()
-        (
-            &[
-                EncoderValType::I32,
-                EncoderValType::I32,
-                EncoderValType::I64,
-                EncoderValType::I32,
-                EncoderValType::I64,
-                EncoderValType::I32,
-            ],
-            &[],
-        ),
+        // 6: (mem_op index: i32) -> ()
+        (&[EncoderValType::I32], &[]),
     ];
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum MemoryOp {
+    Load,
+    Store,
+}
+
+// Compile-time descriptor for a memory instruction
+#[derive(Debug, Copy, Clone)]
+pub struct StaticMemoryAccess {
+    pub op: MemoryOp,
+    pub mem_idx: u32,    // memory index
+    pub addr_slot: u32,  // slot idx for address
+    pub offset: u64,     // concrete addr = slots[addr_slot] + offset
+    pub byte_count: u8,  // can be 1, 2, 4, or 8
+    pub value_slot: u32, // slot idx for value
 }
 
 #[derive(PartialEq, Eq)]
@@ -979,7 +985,10 @@ impl<'a> ValidModule<'a> {
         Ok(ret)
     }
 
-    pub fn build_instrumented_binary(self, types: &TypedModule) -> Result<Vec<u8>> {
+    pub fn build_instrumented_binary(
+        self,
+        types: &TypedModule,
+    ) -> Result<(Vec<u8>, Vec<StaticMemoryAccess>)> {
         use wasm_encoder::*;
         let mut module = Module::default();
 
@@ -1123,24 +1132,22 @@ impl<'a> ValidModule<'a> {
                         && shadow_memory_indices.contains(&(mem_idx as usize))
                         && !bounds_check_to_func_idx.contains_key(&(!is_load).then_some(val_type))
                     {
-                        let ty = (!is_load).then_some(val_type);
-                        let (params, results) = match ty {
+                        let store_ty = (!is_load).then_some(val_type);
+                        let (params, results) = match store_ty {
                             None => (
                                 vec![EncoderValType::I32, EncoderValType::I64], // offset, limit
                                 vec![EncoderValType::I32],                      // offset
                             ),
-                            Some(ty) => {
-                                (
-                                    vec![EncoderValType::I32, ty, EncoderValType::I64], // offset, value, limit
-                                    vec![EncoderValType::I32, ty], // offset, value
-                                )
-                            }
+                            Some(ty) => (
+                                vec![EncoderValType::I32, ty, EncoderValType::I64], // offset, value, limit
+                                vec![EncoderValType::I32, ty],                      // offset, value
+                            ),
                         };
                         debug_assert_eq!(type_section.len(), next_type_idx);
                         type_section.ty().function(params, results);
                         debug_assert_eq!(num_func_imports + function_section.len(), next_func_idx);
                         function_section.function(next_type_idx);
-                        bounds_check_to_func_idx.insert(ty, next_func_idx);
+                        bounds_check_to_func_idx.insert(store_ty, next_func_idx);
                         next_type_idx += 1;
                         next_func_idx += 1;
                     }
@@ -1217,6 +1224,7 @@ impl<'a> ValidModule<'a> {
         /* XXX datacount section: skip for now */
 
         /* Code section */
+        let mut memory_ops: Vec<StaticMemoryAccess> = Vec::new();
         {
             let mut code_section = CodeSection::new();
 
@@ -1229,6 +1237,7 @@ impl<'a> ValidModule<'a> {
                     step_function_idx,
                     &shadow_memory_indices,
                     &bounds_check_to_func_idx,
+                    &mut memory_ops,
                 )?;
                 code_section.function(&function);
             }
@@ -1265,7 +1274,7 @@ impl<'a> ValidModule<'a> {
         /* XXX data section: skip for now */
 
         let wasm = module.finish();
-        Ok(wasm)
+        Ok((wasm, memory_ops))
     }
 
     fn build_function(
@@ -1276,21 +1285,19 @@ impl<'a> ValidModule<'a> {
         step_function_idx: u32,
         shadow_memory_indices: &[usize],
         bounds_check_to_func_idx: &IndexMap<Option<EncoderValType>, u32>,
+        memory_ops: &mut Vec<StaticMemoryAccess>,
     ) -> Result<wasm_encoder::Function> {
         use wasm_encoder::Instruction::*;
         let orig_function = &self.functions[func_idx];
         let typed_function = &types.funcs[func_idx];
         let num_instr_imports = InstrImports::TYPE_INDICES.len() as u32; // also idx of step function
-        let mut locals: Vec<EncoderValType> = orig_function
-            .locals
-            .iter()
-            .map(|ty| RoundtripReencoder.val_type(ty.inner).fmt_err())
-            .collect::<Result<Vec<_>>>()?;
-        locals.push(EncoderValType::I32); // tmp_addr
-        locals.push(EncoderValType::I64); // tmp_bits
-        let mut new_function = wasm_encoder::Function::new_with_locals_types(locals);
-        let tmp_addr = (typed_function.params.len() + orig_function.locals.len()) as u32;
-        let tmp_bits = tmp_addr + 1;
+        let mut new_function = wasm_encoder::Function::new_with_locals_types(
+            orig_function
+                .locals
+                .iter()
+                .map(|ty| RoundtripReencoder.val_type(ty.inner).fmt_err())
+                .collect::<Result<Vec<_>>>()?,
+        );
 
         let transparent_record_results =
             |f: &mut wasm_encoder::Function, results: &Vec<SlotUse>| {
@@ -1329,42 +1336,36 @@ impl<'a> ValidModule<'a> {
             Ok(())
         };
 
-        let memory_record = |f: &mut wasm_encoder::Function,
-                             mem_idx: u32,
-                             offset: u64,
-                             byte_count: u8,
-                             is_load: bool,
-                             val_type: EncoderValType,
-                             op: &wasm_encoder::Instruction<'_>| {
-            let is_float = matches!(val_type, EncoderValType::F32 | EncoderValType::F64) as i32;
-            if is_load {
-                // stack: [..., addr]
-                f.instruction(&LocalTee(tmp_addr)); // save addr, keep on stack
-                f.instruction(op); // pre-read: stack: [..., value]
-                emit_to_bits(f, val_type); // stack: [..., bits]
-                f.instruction(&LocalSet(tmp_bits)); // stack: [...]
-            } else {
-                // stack: [..., addr, value]
-                emit_to_bits(f, val_type); // stack: [..., addr, bits]
-                f.instruction(&LocalSet(tmp_bits)); // stack: [..., addr]
-                f.instruction(&LocalTee(tmp_addr)); // stack: [..., addr]
-            }
-            f.instruction(&I32Const(is_load as i32));
-            f.instruction(&I32Const(mem_idx as i32));
-            f.instruction(&LocalGet(tmp_addr));
-            f.instruction(&I64ExtendI32U);
-            f.instruction(&I64Const(offset as i64));
-            f.instruction(&I64Add); // byte_addr = addr_operand + offset
-            f.instruction(&I32Const(byte_count as i32));
-            f.instruction(&LocalGet(tmp_bits));
-            f.instruction(&I32Const(is_float));
+        let mut memory_record = |f: &mut wasm_encoder::Function,
+                                 mem_idx: u32,
+                                 offset: u64,
+                                 byte_count: u8,
+                                 is_load: bool,
+                                 op_type: &OperatorType| {
+            let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
+            let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
+            let (addr_slot, value_slot) = match (is_load, input0, input1) {
+                (true, Some(SlotUse(a)), _) => (*a as u32, op_type.outputs[0].0 as u32),
+                (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a as u32, *v as u32),
+                _ => return, /* don't record memory footprint in unreachable code */
+            };
+            // Build static lookup table for memory ops
+            let index = memory_ops.len() as i32;
+            memory_ops.push(StaticMemoryAccess {
+                op: if is_load {
+                    MemoryOp::Load
+                } else {
+                    MemoryOp::Store
+                },
+                mem_idx,
+                addr_slot,
+                offset,
+                byte_count,
+                value_slot,
+            });
+            // Wasm instr at runtime: record memory op # just happened
+            f.instruction(&I32Const(index));
             f.instruction(&Call(InstrImports::RecordMemory as u32));
-            // restore stack for actual op:
-            f.instruction(&LocalGet(tmp_addr));
-            if !is_load {
-                f.instruction(&LocalGet(tmp_bits));
-                emit_from_bits(f, val_type); // restore value for store
-            }
         };
 
         let step_debug = |f: &mut wasm_encoder::Function, line_number: usize| {
@@ -1446,22 +1447,6 @@ impl<'a> ValidModule<'a> {
                 ));
             }
 
-            // dynamic memory recording for all memory ops
-            if let Some((mem_idx, offset, width, is_load, val_type)) =
-                memory_op_info(&codillon_operator.inner.op)
-                && !codillon_operator.inner.untyped
-            {
-                memory_record(
-                    &mut new_function,
-                    mem_idx,
-                    offset,
-                    width,
-                    is_load,
-                    val_type,
-                    &op,
-                );
-            }
-
             if i + 1 == orig_function.operators.len() {
                 debug_assert!(matches!(op, End));
                 debug_assert!(codillon_operator.inner.info == OpInfo::FuncEnd);
@@ -1494,7 +1479,7 @@ impl<'a> ValidModule<'a> {
             // record result operands
             transparent_record_results(&mut new_function, &op_type.outputs);
 
-            // did this operator change a global or local or memory
+            // did this operator change a global, local, or memory
             match op {
                 GlobalSet(idx) => {
                     new_function.instruction(&GlobalGet(idx));
@@ -1510,7 +1495,13 @@ impl<'a> ValidModule<'a> {
                         .expect("valid local idx");
                     primitive_record(&mut new_function, local_type)?;
                 }
-                _ => {}
+                _ => {
+                    if let Some((mem_idx, offset, width, is_load, _)) =
+                        memory_op_info(&codillon_operator.inner.op)
+                    {
+                        memory_record(&mut new_function, mem_idx, offset, width, is_load, op_type);
+                    }
+                }
             }
         }
         Ok(new_function)
@@ -1616,42 +1607,6 @@ fn memory_op_info(op: &Operator<'_>) -> Option<(u32, u64, u8, bool, EncoderValTy
         I64Store { memarg } => Some((memarg.memory, memarg.offset, 8, false, EncoderValType::I64)),
         F64Store { memarg } => Some((memarg.memory, memarg.offset, 8, false, EncoderValType::F64)),
         _ => None,
-    }
-}
-
-fn emit_to_bits(f: &mut wasm_encoder::Function, val_type: EncoderValType) {
-    use wasm_encoder::Instruction::*;
-    match val_type {
-        EncoderValType::I32 => {
-            f.instruction(&I64ExtendI32U);
-        }
-        EncoderValType::I64 => {}
-        EncoderValType::F32 => {
-            f.instruction(&I32ReinterpretF32);
-            f.instruction(&I64ExtendI32U);
-        }
-        EncoderValType::F64 => {
-            f.instruction(&I64ReinterpretF64);
-        }
-        _ => unreachable!(),
-    }
-}
-
-fn emit_from_bits(f: &mut wasm_encoder::Function, val_type: EncoderValType) {
-    use wasm_encoder::Instruction::*;
-    match val_type {
-        EncoderValType::I32 => {
-            f.instruction(&I32WrapI64);
-        }
-        EncoderValType::I64 => {}
-        EncoderValType::F32 => {
-            f.instruction(&I32WrapI64);
-            f.instruction(&F32ReinterpretI32);
-        }
-        EncoderValType::F64 => {
-            f.instruction(&F64ReinterpretI64);
-        }
-        _ => unreachable!(),
     }
 }
 
@@ -2617,7 +2572,7 @@ pub(crate) mod tests {
     fn test_parse_memory_section() -> Result<()> {
         fn test_mem(valid_module: ValidModule, mem_value: wasmparser::MemoryType) -> Result<()> {
             let mut mem_exists = false;
-            let wasm_bin = valid_module.build_instrumented_binary(&TypedModule {
+            let (wasm_bin, _) = valid_module.build_instrumented_binary(&TypedModule {
                 slots: vec![],
                 globals: vec![],
                 funcs: vec![],
@@ -2780,7 +2735,7 @@ pub(crate) mod tests {
 
         indent_and_frame(editor, &validized, &types);
 
-        let runnable = validized
+        let (runnable, _) = validized
             .build_instrumented_binary(&types)
             .context("build_executable_binary")?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,11 +60,14 @@ impl InstrImports {
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
         // 5: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
-        // 6: (is_load: i32, addr_slot: i32, byte_count: i32, value_slot: i32) -> ()
+        // 6: (is_load: i32, mem_idx: i32, addr_slot: i32, offset: i64,
+        //     byte_count: i32, value_slot: i32) -> ()
         (
             &[
                 EncoderValType::I32,
                 EncoderValType::I32,
+                EncoderValType::I32,
+                EncoderValType::I64,
                 EncoderValType::I32,
                 EncoderValType::I32,
             ],
@@ -1322,22 +1325,27 @@ impl<'a> ValidModule<'a> {
             Ok(())
         };
 
-        let memory_record =
-            |f: &mut wasm_encoder::Function, byte_count: u8, op_type: &OperatorType| {
-                let is_load = !op_type.outputs.is_empty();
-                let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
-                let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
-                let (addr, value) = match (is_load, input0, input1) {
-                    (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
-                    (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
-                    _ => return, /* don't record memory footprint in unreachable code */
-                };
-                f.instruction(&I32Const(is_load as i32));
-                f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
-                f.instruction(&I32Const(byte_count as i32));
-                f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
-                f.instruction(&Call(InstrImports::RecordMemory as u32));
+        let memory_record = |f: &mut wasm_encoder::Function,
+                             mem_idx: u32,
+                             offset: u64,
+                             byte_count: u8,
+                             op_type: &OperatorType| {
+            let is_load = !op_type.outputs.is_empty();
+            let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
+            let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
+            let (addr, value) = match (is_load, input0, input1) {
+                (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
+                (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
+                _ => return, /* don't record memory footprint in unreachable code */
             };
+            f.instruction(&I32Const(is_load as i32));
+            f.instruction(&I32Const(mem_idx as i32));
+            f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
+            f.instruction(&I64Const(offset as i64));
+            f.instruction(&I32Const(byte_count as i32));
+            f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
+            f.instruction(&Call(InstrImports::RecordMemory as u32));
+        };
 
         let step_debug = |f: &mut wasm_encoder::Function, line_number: usize| {
             // Step before each operator evaluation
@@ -1465,17 +1473,23 @@ impl<'a> ValidModule<'a> {
                     primitive_record(&mut new_function, local_type)?;
                 }
 
-                I32Load8S(_) | I32Load8U(_) | I64Load8S(_) | I64Load8U(_) | I32Store8(_)
-                | I64Store8(_) => memory_record(&mut new_function, 1, op_type),
+                I32Load8S(m) | I32Load8U(m) | I64Load8S(m) | I64Load8U(m) | I32Store8(m)
+                | I64Store8(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 1, op_type)
+                }
 
-                I32Load16S(_) | I32Load16U(_) | I64Load16S(_) | I64Load16U(_) | I32Store16(_)
-                | I64Store16(_) => memory_record(&mut new_function, 2, op_type),
+                I32Load16S(m) | I32Load16U(m) | I64Load16S(m) | I64Load16U(m) | I32Store16(m)
+                | I64Store16(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 2, op_type)
+                }
 
-                I32Load(_) | F32Load(_) | I32Store(_) | F32Store(_) | I64Load32S(_)
-                | I64Load32U(_) | I64Store32(_) => memory_record(&mut new_function, 4, op_type),
+                I32Load(m) | F32Load(m) | I32Store(m) | F32Store(m) | I64Load32S(m)
+                | I64Load32U(m) | I64Store32(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 4, op_type)
+                }
 
-                I64Load(_) | F64Load(_) | I64Store(_) | F64Store(_) => {
-                    memory_record(&mut new_function, 8, op_type)
+                I64Load(m) | F64Load(m) | I64Store(m) | F64Store(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 8, op_type)
                 }
                 _ => {}
             }
@@ -2719,7 +2733,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
-  (type (func (param i32 i32 i32 i32)))
+  (type (func (param i32 i32 i32 i64 i32 i32)))
   (type (func (param i32)))
 "#;
     const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 1)))
@@ -2804,6 +2818,8 @@ pub(crate) mod tests {
     call 9
     i32.const 1
     i32.const 0
+    i32.const 0
+    i64.const 0
     i32.const 4
     i32.const 1
     call 6
@@ -2814,7 +2830,7 @@ pub(crate) mod tests {
     call 8
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 10) (param i32 i32) (result i32)
+                + r#"  (func (type 9) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3833,6 +3849,8 @@ pub(crate) mod tests {
     call 9
     i32.const 1
     i32.const 0
+    i32.const 0
+    i64.const 7
     i32.const 4
     i32.const 1
     call 6
@@ -3906,6 +3924,8 @@ pub(crate) mod tests {
     f64.store offset=1
     i32.const 0
     i32.const 0
+    i32.const 0
+    i64.const 1
     i32.const 8
     i32.const 1
     call 6

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,6 +32,7 @@ enum InstrImports {
     RecordF32,
     RecordI64,
     RecordF64,
+    RecordMemory,
 }
 impl InstrImports {
     const TYPE_INDICES: &'static [(&'static str, u32)] = &[
@@ -41,6 +42,7 @@ impl InstrImports {
         ("record_f32", 4),
         ("record_i64", 5),
         ("record_f64", 6),
+        ("record_memory", 7),
     ];
     const FUNC_SIGS: &'static [(&'static [EncoderValType], &'static [EncoderValType])] = &[
         // 0: () -> () (type of func_placeholder)
@@ -57,6 +59,16 @@ impl InstrImports {
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
         // 6: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
+        // 7: (is_load: i32, addr_slot: i32, byte_count: i32, value_slot: i32) -> ()
+        (
+            &[
+                EncoderValType::I32,
+                EncoderValType::I32,
+                EncoderValType::I32,
+                EncoderValType::I32,
+            ],
+            &[],
+        ),
     ];
 }
 
@@ -1246,6 +1258,23 @@ impl<'a> ValidModule<'a> {
             Ok(())
         };
 
+        let memory_record =
+            |f: &mut wasm_encoder::Function, byte_count: u8, op_type: &OperatorType| {
+                let is_load = !op_type.outputs.is_empty();
+                let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
+                let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
+                let (addr, value) = match (is_load, input0, input1) {
+                    (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
+                    (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
+                    _ => return, /* don't record memory footprint in unreachable code */
+                };
+                f.instruction(&I32Const(is_load as i32));
+                f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
+                f.instruction(&I32Const(byte_count as i32));
+                f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
+                f.instruction(&Call(InstrImports::RecordMemory as u32));
+            };
+
         let step_debug = |f: &mut wasm_encoder::Function, line_number: usize| {
             // Step before each operator evaluation
             f.instruction(&I32Const(line_number.try_into().expect("line_no -> i32")));
@@ -1331,7 +1360,7 @@ impl<'a> ValidModule<'a> {
             // record result operands
             transparent_record_results(&mut new_function, &op_type.outputs);
 
-            // did this operator change a global or local (XXX or memory?)
+            // did this operator change a global or local or memory
             match op {
                 GlobalSet(idx) => {
                     new_function.instruction(&GlobalGet(idx));
@@ -1346,6 +1375,19 @@ impl<'a> ValidModule<'a> {
                         .nth(idx as usize)
                         .expect("valid local idx");
                     primitive_record(&mut new_function, local_type)?;
+                }
+
+                I32Load8S(_) | I32Load8U(_) | I64Load8S(_) | I64Load8U(_) | I32Store8(_)
+                | I64Store8(_) => memory_record(&mut new_function, 1, op_type),
+
+                I32Load16S(_) | I32Load16U(_) | I64Load16S(_) | I64Load16U(_) | I32Store16(_)
+                | I64Store16(_) => memory_record(&mut new_function, 2, op_type),
+
+                I32Load(_) | F32Load(_) | I32Store(_) | F32Store(_) | I64Load32S(_)
+                | I64Load32U(_) | I64Store32(_) => memory_record(&mut new_function, 4, op_type),
+
+                I64Load(_) | F64Load(_) | I64Store(_) | F64Store(_) => {
+                    memory_record(&mut new_function, 8, op_type)
                 }
                 _ => {}
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -991,6 +991,7 @@ impl<'a> ValidModule<'a> {
     ) -> Result<(Vec<u8>, Vec<StaticMemoryAccess>)> {
         use wasm_encoder::*;
         let mut module = Module::default();
+        let mut memory_ops: Vec<StaticMemoryAccess> = Vec::new();
 
         /* Make import section (with instrumentation functions prepended) */
         let (import_section, num_func_imports) = {
@@ -1132,22 +1133,24 @@ impl<'a> ValidModule<'a> {
                         && shadow_memory_indices.contains(&(mem_idx as usize))
                         && !bounds_check_to_func_idx.contains_key(&(!is_load).then_some(val_type))
                     {
-                        let store_ty = (!is_load).then_some(val_type);
-                        let (params, results) = match store_ty {
+                        let ty = (!is_load).then_some(val_type);
+                        let (params, results) = match ty {
                             None => (
                                 vec![EncoderValType::I32, EncoderValType::I64], // offset, limit
                                 vec![EncoderValType::I32],                      // offset
                             ),
-                            Some(ty) => (
-                                vec![EncoderValType::I32, ty, EncoderValType::I64], // offset, value, limit
-                                vec![EncoderValType::I32, ty],                      // offset, value
-                            ),
+                            Some(ty) => {
+                                (
+                                    vec![EncoderValType::I32, ty, EncoderValType::I64], // offset, value, limit
+                                    vec![EncoderValType::I32, ty], // offset, value
+                                )
+                            }
                         };
                         debug_assert_eq!(type_section.len(), next_type_idx);
                         type_section.ty().function(params, results);
                         debug_assert_eq!(num_func_imports + function_section.len(), next_func_idx);
                         function_section.function(next_type_idx);
-                        bounds_check_to_func_idx.insert(store_ty, next_func_idx);
+                        bounds_check_to_func_idx.insert(ty, next_func_idx);
                         next_type_idx += 1;
                         next_func_idx += 1;
                     }
@@ -1224,22 +1227,21 @@ impl<'a> ValidModule<'a> {
         /* XXX datacount section: skip for now */
 
         /* Code section */
-        let mut memory_ops: Vec<StaticMemoryAccess> = Vec::new();
         {
             let mut code_section = CodeSection::new();
 
             // First in code section: the original functions
             for func_idx in 0..self.functions.len() {
-                let function = self.build_function(
+                let (function, func_mem_ops) = self.build_function(
                     func_idx,
                     types,
                     &result_types_to_func_idx,
                     step_function_idx,
                     &shadow_memory_indices,
                     &bounds_check_to_func_idx,
-                    &mut memory_ops,
                 )?;
                 code_section.function(&function);
+                memory_ops.extend(func_mem_ops);
             }
 
             // Next in code section: the "step" function.
@@ -1285,12 +1287,12 @@ impl<'a> ValidModule<'a> {
         step_function_idx: u32,
         shadow_memory_indices: &[usize],
         bounds_check_to_func_idx: &IndexMap<Option<EncoderValType>, u32>,
-        memory_ops: &mut Vec<StaticMemoryAccess>,
-    ) -> Result<wasm_encoder::Function> {
+    ) -> Result<(wasm_encoder::Function, Vec<StaticMemoryAccess>)> {
         use wasm_encoder::Instruction::*;
         let orig_function = &self.functions[func_idx];
         let typed_function = &types.funcs[func_idx];
         let num_instr_imports = InstrImports::TYPE_INDICES.len() as u32; // also idx of step function
+        let mut memory_ops: Vec<StaticMemoryAccess> = Vec::new();
         let mut new_function = wasm_encoder::Function::new_with_locals_types(
             orig_function
                 .locals
@@ -1504,7 +1506,7 @@ impl<'a> ValidModule<'a> {
                 }
             }
         }
-        Ok(new_function)
+        Ok((new_function, memory_ops))
     }
 
     fn dynamically_generate_function(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2719,6 +2719,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
+  (type (func (param i32 i32 i32 i32)))
   (type (func (param i32)))
 "#;
     const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 1)))
@@ -2727,12 +2728,13 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f32" (func (type 4)))
   (import "codillon_debug" "record_i64" (func (type 5)))
   (import "codillon_debug" "record_f64" (func (type 6)))
+  (import "codillon_debug" "record_memory" (func (type 7)))
 "#;
 
-    const EXPECTED_MAIN: &str = r#"  (export "main" (func 6))
+    const EXPECTED_MAIN: &str = r#"  (export "main" (func 7))
 "#;
 
-    const EXPECTED_STEP: &str = r#"  (func (type 7) (param i32)
+    const EXPECTED_STEP: &str = r#"  (func (type 8) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -2741,7 +2743,7 @@ pub(crate) mod tests {
     end
   )
 "#;
-    const EXPECTED_RECORD_I32: &str = r#"  (func (type 8) (param i32 i32) (result i32)
+    const EXPECTED_RECORD_I32: &str = r#"  (func (type 9) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -2763,9 +2765,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 0
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2782,9 +2784,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2801,9 +2803,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 1
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2820,9 +2822,9 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -2841,20 +2843,20 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
-    i32.const 0
-    call 7
-    i64.const 17
+    call 8
     i32.const 0
     call 8
+    i64.const 17
+    i32.const 0
+    call 9
     i32.const 1
-    call 7
+    call 8
     drop
     i32.const 2
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 8) (param i64 i32) (result i64)
+                + r#"  (func (type 9) (param i64 i32) (result i64)
     local.get 0
     local.get 1
     call 4
@@ -2867,15 +2869,15 @@ pub(crate) mod tests {
 
         // well-formed block
         const JUST_BLOCK_END: &str = r#"    i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     block ;; label = @1
       i32.const 2
-      call 7
+      call 8
     end
     i32.const 3
-    call 7
+    call 8
   )
 "#;
         {
@@ -2928,25 +2930,25 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 137
     i32.const 0
-    call 8
+    call 9
     i32.const 2
-    call 7
+    call 8
     i32.const 2
     call 1
     unreachable
     i32.add
     i32.const 3
-    call 8
+    call 9
     i32.const 3
-    call 7
+    call 8
     drop
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + EXPECTED_RECORD_I32
@@ -2969,12 +2971,12 @@ pub(crate) mod tests {
                 + EXPECTED_TYPES
                 + EXPECTED_IMPORTS
                 + r#"  (import "codillon_debug" "func_placeholder" (func (type 0)))
-  (export "main" (func 7))
+  (export "main" (func 8))
   (func (type 0)
     i32.const 6
-    call 8
+    call 9
     i32.const 6
-    call 8
+    call 9
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3019,21 +3021,21 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     block ;; label = @1
       i32.const 2
-      call 7
+      call 8
       loop ;; label = @2
         i32.const 4
-        call 7
+        call 8
       end
       i32.const 5
-      call 7
+      call 8
     end
     i32.const 6
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3052,15 +3054,15 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 1
     call 1
     unreachable
     nop
     i32.const 2
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3082,21 +3084,21 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 1
-    call 7
+    call 8
     i32.const 2
-    call 7
+    call 8
     i32.const 2
     call 1
     unreachable
     nop
     i32.const 3
-    call 7
+    call 8
     i32.const 3
     call 1
     unreachable
     drop
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3117,23 +3119,23 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 0
-    call 7
+    call 8
     loop ;; label = @1
       i32.const 1
-      call 7
+      call 8
       i32.const 5
       i32.const 0
-      call 8
+      call 9
       i32.const 2
-      call 7
+      call 8
       br 0 (;@1;)
       i32.const 3
-      call 7
+      call 8
     end
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + EXPECTED_RECORD_I32
@@ -3155,14 +3157,14 @@ pub(crate) mod tests {
                 + EXPECTED_MAIN
                 + r#"  (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 4
     i32.const 0
-    call 8
+    call 9
     i32.const 2
-    call 7
+    call 8
     i32.const 2
     call 1
     unreachable
@@ -3196,49 +3198,50 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f32" (func (type 5)))
   (import "codillon_debug" "record_i64" (func (type 6)))
   (import "codillon_debug" "record_f64" (func (type 7)))
-  (export "main" (func 6))
+  (import "codillon_debug" "record_memory" (func (type 8)))
+  (export "main" (func 7))
   (func (type 0)
     i32.const 0
-    call 8
-    i32.const 1
-    call 8
-    call 7
-    i32.const 1
-    call 8
-    i32.const 0
+    call 9
     i32.const 1
     call 9
-    i32.const 2
     call 8
+    i32.const 1
+    call 9
+    i32.const 0
+    i32.const 1
+    call 10
+    i32.const 2
+    call 9
     i32.add
     i32.const 2
-    call 10
+    call 11
     i32.const 3
-    call 8
+    call 9
     i32.const 3
     call 1
     unreachable
   )
   (func (type 1) (result i32 i32)
     i32.const 4
-    call 8
+    call 9
     i32.const 5
-    call 8
+    call 9
     i32.const 9
     i32.const 3
-    call 10
-    i32.const 6
-    call 8
-    i32.const 10
-    i32.const 4
-    call 10
-    i32.const 7
-    call 8
-    i32.const 5
+    call 11
     i32.const 6
     call 9
+    i32.const 10
+    i32.const 4
+    call 11
+    i32.const 7
+    call 9
+    i32.const 5
+    i32.const 6
+    call 10
   )
-  (func (type 8) (param i32)
+  (func (type 9) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -3246,7 +3249,7 @@ pub(crate) mod tests {
       unreachable
     end
   )
-  (func (type 9) (param i32 i32 i32 i32) (result i32 i32)
+  (func (type 10) (param i32 i32 i32 i32) (result i32 i32)
     local.get 0
     local.get 2
     call 2
@@ -3256,7 +3259,7 @@ pub(crate) mod tests {
     local.get 0
     local.get 1
   )
-  (func (type 10) (param i32 i32) (result i32)
+  (func (type 11) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3298,9 +3301,9 @@ pub(crate) mod tests {
     i32.const 3
     call 5
     i32.const 0
-    call 7
+    call 8
     i32.const 4
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3326,28 +3329,29 @@ pub(crate) mod tests {
   (import "codillon_debug" "record_f32" (func (type 5)))
   (import "codillon_debug" "record_i64" (func (type 6)))
   (import "codillon_debug" "record_f64" (func (type 7)))
-  (export "main" (func 6))
+  (import "codillon_debug" "record_memory" (func (type 8)))
+  (export "main" (func 7))
   (func (type 0)
     i32.const 0
-    call 7
+    call 8
     i32.const 1
-    call 7
+    call 8
     i32.const 1
     call 1
     unreachable
     block (type 1) (param i32) ;; label = @1
       i32.const 1
-      call 8
+      call 9
       i32.const 2
-      call 7
+      call 8
       i32.const 2
       call 1
       unreachable
     end
     i32.const 3
-    call 7
+    call 8
   )
-  (func (type 8) (param i32)
+  (func (type 9) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -3355,7 +3359,7 @@ pub(crate) mod tests {
       unreachable
     end
   )
-  (func (type 9) (param i32 i32) (result i32)
+  (func (type 10) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3381,17 +3385,17 @@ pub(crate) mod tests {
                 + EXPECTED_TYPES
                 + EXPECTED_IMPORTS
                 + r#"  (import "codillon_debug" "func_placeholder" (func (type 0)))
-  (export "main" (func 7))
+  (export "main" (func 8))
   (func (type 0)
     i32.const 1
-    call 8
+    call 9
     i32.const 2
-    call 8
-    call 6
+    call 9
+    call 7
     i32.const 2
-    call 8
+    call 9
     i32.const 3
-    call 8
+    call 9
   )
 "# + EXPECTED_STEP
                 + ")\n";
@@ -3759,32 +3763,37 @@ pub(crate) mod tests {
 "# + EXPECTED_IMPORTS
                 + r#"  (memory 1)
   (global (mut i64) i64.const 11)
-  (export "main" (func 6))
+  (export "main" (func 7))
   (func (type 0) (result i32)
     i32.const 1
-    call 7
-    i32.const 3
-    call 7
-    i32.const 0
-    i32.const 0
     call 8
+    i32.const 3
+    call 8
+    i32.const 0
+    i32.const 0
+    call 9
     i32.const 4
-    call 7
+    call 8
     global.get 0
     i64.const 11
     i64.sub
-    call 9
+    call 10
     i32.load offset=7
     i32.const 1
-    call 8
+    call 9
+    i32.const 1
+    i32.const 0
+    i32.const 4
+    i32.const 1
+    call 6
     i32.const 5
-    call 7
-    i32.const 2
     call 8
+    i32.const 2
+    call 9
   )
 "# + EXPECTED_STEP
                 + EXPECTED_RECORD_I32
-                + r#"  (func (type 9) (param i32 i64) (result i32)
+                + r#"  (func (type 10) (param i32 i64) (result i32)
     local.get 0
     i64.extend_i32_u
     local.get 1
@@ -3824,39 +3833,44 @@ pub(crate) mod tests {
 "# + EXPECTED_IMPORTS
                 + r#"  (memory 65536)
   (global (mut i64) i64.const 4294967295)
-  (export "main" (func 6))
+  (export "main" (func 7))
   (func (type 0)
     i32.const 1
-    call 7
+    call 8
     i32.const 2
-    call 7
+    call 8
     i32.const -10
     i32.const 0
-    call 8
+    call 9
     i32.const 3
-    call 7
+    call 8
     f64.const 0x1.cp+2 (;=7;)
     i32.const 1
-    call 9
+    call 10
     i32.const 4
-    call 7
+    call 8
     global.get 0
     i64.const 9
     i64.sub
-    call 10
+    call 11
     f64.store offset=1
+    i32.const 0
+    i32.const 0
+    i32.const 8
+    i32.const 1
+    call 6
     i32.const 5
-    call 7
+    call 8
   )
 "# + EXPECTED_STEP
                 + EXPECTED_RECORD_I32
-                + r#"  (func (type 9) (param f64 i32) (result f64)
+                + r#"  (func (type 10) (param f64 i32) (result f64)
     local.get 0
     local.get 1
     call 5
     local.get 0
   )
-  (func (type 10) (param i32 f64 i64) (result i32 f64)
+  (func (type 11) (param i32 f64 i64) (result i32 f64)
     local.get 0
     i64.extend_i32_u
     local.get 2

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,11 +59,14 @@ impl InstrImports {
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
         // 6: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
-        // 7: (is_load: i32, addr_slot: i32, byte_count: i32, value_slot: i32) -> ()
+        // 7: (is_load: i32, mem_idx: i32, addr_slot: i32, offset: i64,
+        //     byte_count: i32, value_slot: i32) -> ()
         (
             &[
                 EncoderValType::I32,
                 EncoderValType::I32,
+                EncoderValType::I32,
+                EncoderValType::I64,
                 EncoderValType::I32,
                 EncoderValType::I32,
             ],
@@ -1258,22 +1261,27 @@ impl<'a> ValidModule<'a> {
             Ok(())
         };
 
-        let memory_record =
-            |f: &mut wasm_encoder::Function, byte_count: u8, op_type: &OperatorType| {
-                let is_load = !op_type.outputs.is_empty();
-                let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
-                let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
-                let (addr, value) = match (is_load, input0, input1) {
-                    (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
-                    (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
-                    _ => return, /* don't record memory footprint in unreachable code */
-                };
-                f.instruction(&I32Const(is_load as i32));
-                f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
-                f.instruction(&I32Const(byte_count as i32));
-                f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
-                f.instruction(&Call(InstrImports::RecordMemory as u32));
+        let memory_record = |f: &mut wasm_encoder::Function,
+                             mem_idx: u32,
+                             offset: u64,
+                             byte_count: u8,
+                             op_type: &OperatorType| {
+            let is_load = !op_type.outputs.is_empty();
+            let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
+            let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
+            let (addr, value) = match (is_load, input0, input1) {
+                (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
+                (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
+                _ => return, /* don't record memory footprint in unreachable code */
             };
+            f.instruction(&I32Const(is_load as i32));
+            f.instruction(&I32Const(mem_idx as i32));
+            f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
+            f.instruction(&I64Const(offset as i64));
+            f.instruction(&I32Const(byte_count as i32));
+            f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
+            f.instruction(&Call(InstrImports::RecordMemory as u32));
+        };
 
         let step_debug = |f: &mut wasm_encoder::Function, line_number: usize| {
             // Step before each operator evaluation
@@ -1377,17 +1385,23 @@ impl<'a> ValidModule<'a> {
                     primitive_record(&mut new_function, local_type)?;
                 }
 
-                I32Load8S(_) | I32Load8U(_) | I64Load8S(_) | I64Load8U(_) | I32Store8(_)
-                | I64Store8(_) => memory_record(&mut new_function, 1, op_type),
+                I32Load8S(m) | I32Load8U(m) | I64Load8S(m) | I64Load8U(m) | I32Store8(m)
+                | I64Store8(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 1, op_type)
+                }
 
-                I32Load16S(_) | I32Load16U(_) | I64Load16S(_) | I64Load16U(_) | I32Store16(_)
-                | I64Store16(_) => memory_record(&mut new_function, 2, op_type),
+                I32Load16S(m) | I32Load16U(m) | I64Load16S(m) | I64Load16U(m) | I32Store16(m)
+                | I64Store16(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 2, op_type)
+                }
 
-                I32Load(_) | F32Load(_) | I32Store(_) | F32Store(_) | I64Load32S(_)
-                | I64Load32U(_) | I64Store32(_) => memory_record(&mut new_function, 4, op_type),
+                I32Load(m) | F32Load(m) | I32Store(m) | F32Store(m) | I64Load32S(m)
+                | I64Load32U(m) | I64Store32(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 4, op_type)
+                }
 
-                I64Load(_) | F64Load(_) | I64Store(_) | F64Store(_) => {
-                    memory_record(&mut new_function, 8, op_type)
+                I64Load(m) | F64Load(m) | I64Store(m) | F64Store(m) => {
+                    memory_record(&mut new_function, m.memory_index, m.offset, 8, op_type)
                 }
                 _ => {}
             }
@@ -2483,7 +2497,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
-  (type (func (param i32 i32 i32 i32)))
+  (type (func (param i32 i32 i32 i64 i32 i32)))
   (type (func (param i32)))
 "#;
     const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 2)))
@@ -2561,6 +2575,8 @@ pub(crate) mod tests {
     call 9
     i32.const 1
     i32.const 0
+    i32.const 0
+    i64.const 0
     i32.const 4
     i32.const 1
     call 6
@@ -3021,7 +3037,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
-  (type (func (param i32 i32 i32 i32)))
+  (type (func (param i32 i32 i32 i64 i32 i32)))
   (type (func (param i32)))
   (type (func (param i32 i32 i32 i32) (result i32 i32)))
   (type (func (param i32 i32) (result i32)))
@@ -3157,7 +3173,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
-  (type (func (param i32 i32 i32 i32)))
+  (type (func (param i32 i32 i32 i64 i32 i32)))
   (type (func (param i32)))
   (type (func (param i32 i32) (result i32)))
   (import "codillon_debug" "record_step" (func (type 3)))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2774,6 +2774,56 @@ pub(crate) mod tests {
             assert_eq!(expected, test_editor_flow(&mut editor)?);
         }
 
+        // instrumentation for memory track
+        {
+            let mut editor = FakeTextBuffer::default();
+            editor.push_line("(memory 1)");
+            editor.push_line("(func");
+            editor.push_line("i32.const 0");
+            editor.push_line("i32.load");
+            editor.push_line("drop");
+            editor.push_line(")");
+            let expected = String::from("(module\n")
+                + EXPECTED_TYPES
+                + "  (type (func (param i32 i32) (result i32)))\n"
+                + EXPECTED_IMPORTS
+                + "  (memory 1)\n"
+                + EXPECTED_MAIN
+                + r#"  (func (type 0)
+    i32.const 1
+    call 8
+    i32.const 2
+    call 8
+    i32.const 0
+    i32.const 0
+    call 9
+    i32.const 3
+    call 8
+    i32.load
+    i32.const 1
+    call 9
+    i32.const 1
+    i32.const 0
+    i32.const 4
+    i32.const 1
+    call 6
+    i32.const 4
+    call 8
+    drop
+    i32.const 5
+    call 8
+  )
+"# + EXPECTED_STEP
+                + r#"  (func (type 10) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    call 2
+    local.get 0
+  )
+"# + ")\n";
+            assert_eq!(expected, test_editor_flow(&mut editor)?);
+        }
+
         // syntax error (synthesizes closing paren)
         {
             let mut editor = FakeTextBuffer::default();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2759,7 +2759,7 @@ pub(crate) mod tests {
   (type (func (param f32 i32)))
   (type (func (param i64 i32)))
   (type (func (param f64 i32)))
-  (type (func (param i32 i32 i32 i64 i32 i32)))
+  (type (func (param i32)))
   (type (func (param i32)))
 "#;
     const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 1)))
@@ -2842,12 +2842,7 @@ pub(crate) mod tests {
     i32.load
     i32.const 1
     call 9
-    i32.const 1
     i32.const 0
-    i32.const 0
-    i64.const 0
-    i32.const 4
-    i32.const 1
     call 6
     i32.const 4
     call 8
@@ -3873,12 +3868,7 @@ pub(crate) mod tests {
     i32.load offset=7
     i32.const 1
     call 9
-    i32.const 1
     i32.const 0
-    i32.const 0
-    i64.const 7
-    i32.const 4
-    i32.const 1
     call 6
     i32.const 5
     call 8
@@ -3949,11 +3939,6 @@ pub(crate) mod tests {
     call 11
     f64.store offset=1
     i32.const 0
-    i32.const 0
-    i32.const 0
-    i64.const 1
-    i32.const 8
-    i32.const 1
     call 6
     i32.const 5
     call 8

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2531,6 +2531,56 @@ pub(crate) mod tests {
             assert_eq!(expected, test_editor_flow(&mut editor)?);
         }
 
+        // instrumentation for memory track
+        {
+            let mut editor = FakeTextBuffer::default();
+            editor.push_line("(memory 1)");
+            editor.push_line("(func");
+            editor.push_line("i32.const 0");
+            editor.push_line("i32.load");
+            editor.push_line("drop");
+            editor.push_line(")");
+            let expected = String::from("(module\n")
+                + EXPECTED_TYPES
+                + "  (type (func (param i32 i32) (result i32)))\n"
+                + EXPECTED_IMPORTS
+                + "  (memory 1)\n"
+                + EXPECTED_MAIN
+                + r#"  (func (type 0)
+    i32.const 1
+    call 8
+    i32.const 2
+    call 8
+    i32.const 0
+    i32.const 0
+    call 9
+    i32.const 3
+    call 8
+    i32.load
+    i32.const 1
+    call 9
+    i32.const 1
+    i32.const 0
+    i32.const 4
+    i32.const 1
+    call 6
+    i32.const 4
+    call 8
+    drop
+    i32.const 5
+    call 8
+  )
+"# + EXPECTED_STEP
+                + r#"  (func (type 10) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    call 2
+    local.get 0
+  )
+"# + ")\n";
+            assert_eq!(expected, test_editor_flow(&mut editor)?);
+        }
+
         // syntax error (synthesizes closing paren)
         {
             let mut editor = FakeTextBuffer::default();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,6 +35,7 @@ enum InstrImports {
     RecordF32,
     RecordI64,
     RecordF64,
+    RecordMemory,
 }
 impl InstrImports {
     const TYPE_INDICES: &'static [(&'static str, u32)] = &[
@@ -44,6 +45,7 @@ impl InstrImports {
         ("record_f32", 3),
         ("record_i64", 4),
         ("record_f64", 5),
+        ("record_memory", 6),
     ];
     const FUNC_SIGS: &'static [(&'static [EncoderValType], &'static [EncoderValType])] = &[
         // 0: i32 -> i32
@@ -58,6 +60,16 @@ impl InstrImports {
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
         // 5: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
+        // 6: (is_load: i32, addr_slot: i32, byte_count: i32, value_slot: i32) -> ()
+        (
+            &[
+                EncoderValType::I32,
+                EncoderValType::I32,
+                EncoderValType::I32,
+                EncoderValType::I32,
+            ],
+            &[],
+        ),
     ];
 }
 
@@ -1310,6 +1322,23 @@ impl<'a> ValidModule<'a> {
             Ok(())
         };
 
+        let memory_record =
+            |f: &mut wasm_encoder::Function, byte_count: u8, op_type: &OperatorType| {
+                let is_load = !op_type.outputs.is_empty();
+                let input0 = op_type.inputs.first().and_then(|s| s.as_ref());
+                let input1 = op_type.inputs.get(1).and_then(|s| s.as_ref());
+                let (addr, value) = match (is_load, input0, input1) {
+                    (true, Some(SlotUse(a)), _) => (*a, op_type.outputs[0].0),
+                    (false, Some(SlotUse(a)), Some(SlotUse(v))) => (*a, *v),
+                    _ => return, /* don't record memory footprint in unreachable code */
+                };
+                f.instruction(&I32Const(is_load as i32));
+                f.instruction(&I32Const(addr.try_into().expect("slot -> i32")));
+                f.instruction(&I32Const(byte_count as i32));
+                f.instruction(&I32Const(value.try_into().expect("slot -> i32")));
+                f.instruction(&Call(InstrImports::RecordMemory as u32));
+            };
+
         let step_debug = |f: &mut wasm_encoder::Function, line_number: usize| {
             // Step before each operator evaluation
             f.instruction(&I32Const(line_number.try_into().expect("line_no -> i32")));
@@ -1419,7 +1448,7 @@ impl<'a> ValidModule<'a> {
             // record result operands
             transparent_record_results(&mut new_function, &op_type.outputs);
 
-            // did this operator change a global or local (XXX or memory?)
+            // did this operator change a global or local or memory
             match op {
                 GlobalSet(idx) => {
                     new_function.instruction(&GlobalGet(idx));
@@ -1434,6 +1463,19 @@ impl<'a> ValidModule<'a> {
                         .nth(idx as usize)
                         .expect("valid local idx");
                     primitive_record(&mut new_function, local_type)?;
+                }
+
+                I32Load8S(_) | I32Load8U(_) | I64Load8S(_) | I64Load8U(_) | I32Store8(_)
+                | I64Store8(_) => memory_record(&mut new_function, 1, op_type),
+
+                I32Load16S(_) | I32Load16U(_) | I64Load16S(_) | I64Load16U(_) | I32Store16(_)
+                | I64Store16(_) => memory_record(&mut new_function, 2, op_type),
+
+                I32Load(_) | F32Load(_) | I32Store(_) | F32Store(_) | I64Load32S(_)
+                | I64Load32U(_) | I64Store32(_) => memory_record(&mut new_function, 4, op_type),
+
+                I64Load(_) | F64Load(_) | I64Store(_) | F64Store(_) => {
+                    memory_record(&mut new_function, 8, op_type)
                 }
                 _ => {}
             }


### PR DESCRIPTION
**PR summary (issue #137):**

- Instrument every wasm load/store to record the operation type (load or store), address slot, number of bytes (1/2/4/8), and value slot into each ExecutionStep
- Add test to test_fixes to see the memory instrumentation function works
- Notes:
  - page index is not added, as it's can be easily get from address / 65536 (https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances)
  - thorough test for the correctness of recorded memory values are not added, due to the lack of infra for running wasm bin in tests. By running a simple console log in goto_step, the result seems fine
<img width="1920" height="947" alt="fee83cb0e4075951f9cc29c19e3aa3a0" src="https://github.com/user-attachments/assets/a2f1fe49-41dd-4506-a784-c521702a165e" />
<img width="1920" height="947" alt="429177e99238433122239ebba987ad04" src="https://github.com/user-attachments/assets/936e040c-9137-4b97-a1b5-0ab87f4c07df" />
