### PR TITLE
Fix another "bounce" case

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -664,6 +664,22 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
         // If line will be rejected in second pass, don't let it define a symbol.
         let orig_state = state;
+
+        if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
+            match state {
+                // Fix #2 (simulation from below): prepend "(func" if an instruction appears at module scope
+                Initial => {
+                    let _ = state.transit_state_from_module_part(ModulePart::LParen);
+                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
+                }
+                // Fix #3 (simulation from below): prepend "func" if an instruction appears after just "("
+                AfterModuleFieldLParen => {
+                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
+                }
+                _ => {}
+            }
+        }
+
         if state.transit_state(lines.info(line_no), |_| {}).is_err() {
             state = orig_state;
             continue;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3278,6 +3278,17 @@ pub(crate) mod tests {
             test_editor_flow(&mut editor)?;
         }
 
+        {
+            // issue #242
+            let mut editor = FakeTextBuffer::default();
+            editor.push_line("(func");
+            editor.push_line("call $x");
+            editor.push_line(")");
+            editor.push_line("nop");
+            editor.push_line("(func $x)");
+            test_editor_flow(&mut editor)?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
(by making fix_syntax's first pass better simulate the second pass)

Fixes: #242