### PR TITLE
Fix several bugs related to imports

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -5,14 +5,14 @@ use crate::symbolic::{
     ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
     symbols_resolved,
 };
+use crate::utils::{HelperImportKind, check_import};
 use anyhow::Result;
 use std::collections::HashSet;
-use wast::core::{Limits, MemoryType};
 use wast::{
     Error,
     core::{
-        Export, Global, Imports, InlineExport, InlineImport, Instruction, LocalParser, Memory,
-        Table, ValType,
+        Export, Global, Imports, InlineExport, InlineImport, Instruction, ItemKind, Limits,
+        LocalParser, Memory, MemoryType, Table, ValType,
     },
     kw,
     parser::{self, Cursor, Parse, ParseBuffer, Parser, Peek},
@@ -214,22 +214,28 @@ impl<'a> Parse<'a> for ModulePart {
                     Imports {
                         items:
                             wast::core::ImportItems::Single {
-                                sig:
-                                    wast::core::ItemSig {
-                                        kind:
-                                            wast::core::ItemKind::Func { .. }
-                                            | wast::core::ItemKind::Global(_)
-                                            | wast::core::ItemKind::Memory(MemoryType {
-                                                shared: false,
-                                                limits: Limits { is64: false, .. },
-                                                ..
-                                            }),
-                                        ..
-                                    },
-                                ..
+                                module,
+                                name,
+                                sig: wast::core::ItemSig { ref kind, .. },
                             },
                         ..
-                    } => Ok(imports.into()),
+                    } => match kind {
+                        ItemKind::Func(_) => Ok(imports.into()),
+                        ItemKind::Global(ty) => {
+                            match check_import(module, name, &HelperImportKind::Global(*ty)) {
+                                None => Ok(imports.into()),
+                                Some(error_message) => Err(parser.error(error_message)),
+                            }
+                        }
+                        ItemKind::Memory(ty) => {
+                            match check_import(module, name, &HelperImportKind::Memory(*ty)) {
+                                None => Ok(imports.into()),
+                                Some(error_message) => Err(parser.error(error_message)),
+                            }
+                        }
+                        _ => Err(parser.error("unsupported import kind")),
+                    },
+
                     _ => Err(parser.error("unsupported import kind")),
                 }
             })
@@ -268,16 +274,15 @@ impl<'a> Parse<'a> for ModulePart {
                 Memory {
                     kind:
                         wast::core::MemoryKind::Import {
-                            ty:
-                                MemoryType {
-                                    shared: false,
-                                    limits: Limits { is64: false, .. },
-                                    ..
-                                },
+                            import: InlineImport { module, field },
+                            ty,
                             ..
                         },
                     ..
-                } => Ok(ModulePart::Import),
+                } => match check_import(module, field, &HelperImportKind::Memory(ty)) {
+                    None => Ok(ModulePart::Import),
+                    Some(error_message) => Err(parser.error(error_message)),
+                },
                 Memory {
                     kind:
                         wast::core::MemoryKind::Normal(MemoryType {
@@ -287,7 +292,7 @@ impl<'a> Parse<'a> for ModulePart {
                         }),
                     ..
                 } => Ok(ModulePart::Memory),
-                _ => Err(parser.error("unsupported memory kind")),
+                _ => Err(parser.error("unsupported memory feature")),
             })
         } else if parser.peek2::<kw::table>()? {
             parser.parens(|p| match p.parse::<Table<'a>>()? {
@@ -300,9 +305,13 @@ impl<'a> Parse<'a> for ModulePart {
         } else if parser.peek2::<kw::global>()? {
             parser.parens(|p| match p.parse::<Global<'a>>()? {
                 Global {
-                    kind: wast::core::GlobalKind::Import { .. },
+                    kind: wast::core::GlobalKind::Import(InlineImport { module, field }),
+                    ty,
                     ..
-                } => Ok(ModulePart::Import),
+                } => match check_import(module, field, &HelperImportKind::Global(ty)) {
+                    None => Ok(ModulePart::Import),
+                    Some(error_message) => Err(parser.error(error_message)),
+                },
                 Global {
                     kind: wast::core::GlobalKind::Inline(wast::core::Expression { instrs, .. }),
                     ty:
@@ -536,6 +545,7 @@ impl SyntaxState {
         let mut hit_initial = false;
         let mut has_local = false;
         let mut has_result = false;
+        let mut has_import = false;
         match &info.kind {
             LineKind::Empty | LineKind::Malformed(_) => {}
             LineKind::Instr(_) => {
@@ -568,11 +578,22 @@ impl SyntaxState {
                     self.transit_state_from_module_part(*part)?;
                     callback(self);
 
+                    if matches!(
+                        *self,
+                        SyntaxState::AfterFuncHeader(FuncHeader {
+                            is_import: true,
+                            ..
+                        })
+                    ) {
+                        has_import = true;
+                    }
+
                     if *self == SyntaxState::Initial {
                         hit_initial = true;
-                        if has_result {
+                        if has_result && !has_import {
                             return Err("function with results must end on another line");
                         }
+                        has_import = false;
                     }
                 }
             }
@@ -652,6 +673,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     // and declare module-scope symbolic ids for any surviving lines.
 
     // There are probably still cases that can produce a "bounce."
+    let mut saw_func = false;
     for line_no in 0..lines.len() {
         lines.set_synthetic_before(line_no, SyntheticWasm::default());
         lines.set_active_status(line_no, Active);
@@ -659,6 +681,42 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
         lines.set_runtime_error(line_no, None);
 
         let line_kind = lines.info(line_no).kind.stripped_clone();
+
+        // If line will be rejected in second pass, don't let it define a symbol.
+        let orig_state = state;
+
+        if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
+            match state {
+                // Fix #2 (simulation from below): prepend "(func" if an instruction appears at module scope
+                Initial => {
+                    let _ = state.transit_state_from_module_part(ModulePart::LParen);
+                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
+                }
+                // Fix #3 (simulation from below): prepend "func" if an instruction appears after just "("
+                AfterModuleFieldLParen => {
+                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
+                }
+                _ => {}
+            }
+        }
+
+        if state
+            .transit_state(lines.info(line_no), |st| match st {
+                SyntaxState::AfterFuncHeader(FuncHeader {
+                    is_import: true, ..
+                }) => saw_func = false,
+                SyntaxState::AfterFuncHeader(_) => saw_func = true,
+                _ => {}
+            })
+            .is_err()
+        {
+            state = orig_state;
+            continue;
+        }
+
+        if saw_func && state == SyntaxState::Initial {
+            before_imports = false;
+        }
 
         // Enforce no imports after other module fields
         if let LineKind::Other(parts) = &line_kind {
@@ -680,32 +738,9 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                     Inactive("imports must appear before other module fields"),
                 );
                 continue;
-            } else if module_field || (parts.contains(&ModulePart::RParen) && !has_import) {
+            } else if module_field {
                 before_imports = false;
             }
-        }
-
-        // If line will be rejected in second pass, don't let it define a symbol.
-        let orig_state = state;
-
-        if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
-            match state {
-                // Fix #2 (simulation from below): prepend "(func" if an instruction appears at module scope
-                Initial => {
-                    let _ = state.transit_state_from_module_part(ModulePart::LParen);
-                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
-                }
-                // Fix #3 (simulation from below): prepend "func" if an instruction appears after just "("
-                AfterModuleFieldLParen => {
-                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
-                }
-                _ => {}
-            }
-        }
-
-        if state.transit_state(lines.info(line_no), |_| {}).is_err() {
-            state = orig_state;
-            continue;
         }
 
         // Collect module-level symbols
@@ -1378,6 +1413,63 @@ mod tests {
             fix_syntax(&mut infos6);
             assert!(infos6.lines[0].is_active());
             assert!(!infos6.lines[1].is_active());
+        }
+
+        {
+            // Import with params and results on one line
+            let mut infos =
+                TestLineInfos::new(["(func $x (import \"x\" \"y\") (param i32) (result f64))"]);
+            fix_syntax(&mut infos);
+            assert!(infos.lines[0].is_well_formed());
+        }
+
+        {
+            // Func with params and results on one line
+            let mut infos = TestLineInfos::new(["(func $x (param i32) (result f64))"]);
+            fix_syntax(&mut infos);
+            assert!(!infos.lines[0].is_well_formed());
+        }
+
+        {
+            // Multi-line imported function, then a non-import module field
+            let mut infos = TestLineInfos::new([
+                "(func $x (import \"x\" \"y\") (param i32)",
+                "(result f64))",
+                "(memory 1)",
+            ]);
+            fix_syntax(&mut infos);
+            assert!(infos.lines[0].is_well_formed());
+            assert!(infos.lines[1].is_well_formed());
+            assert!(infos.lines[2].is_well_formed());
+        }
+
+        {
+            // Multi-line imported function, then another import
+            let mut infos = TestLineInfos::new([
+                "(func $x (import \"x\" \"y\") (param i32)",
+                "(result f64))",
+                "(memory (import \"listen\" \"listen_memory\") 1)",
+            ]);
+            fix_syntax(&mut infos);
+            assert!(infos.lines[0].is_well_formed());
+            assert!(infos.lines[1].is_well_formed());
+            assert!(infos.lines[2].is_well_formed());
+        }
+
+        {
+            // Bad global import
+            let mut infos = TestLineInfos::new(["(global (import \"x\" \"y\") i32)"]);
+            fix_syntax(&mut infos);
+            dbg!(&infos.lines[0]);
+            assert!(!infos.lines[0].is_well_formed());
+        }
+
+        {
+            // Bad memory import
+            let mut infos = TestLineInfos::new(["(memory (import \"x\" \"y\") 1)"]);
+            fix_syntax(&mut infos);
+            dbg!(&infos.lines[0]);
+            assert!(!infos.lines[0].is_well_formed());
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,10 @@ use wasmparser::{
     Validator, WasmFeatures, WasmModuleResources,
 };
 use wast::{
-    core::Module,
+    core::{
+        GlobalType as TextGlobalType, Limits as TextLimits, MemoryType as TextMemoryType, Module,
+        ValType as TextValType,
+    },
     parser::{self, ParseBuffer},
 };
 
@@ -35,39 +38,37 @@ enum InstrImports {
 }
 impl InstrImports {
     const TYPE_INDICES: &'static [(&'static str, u32)] = &[
-        ("record_step", 1), // indices relative to end of user-provided type section
-        ("record_invalid", 2),
-        ("record_i32", 3),
-        ("record_f32", 4),
-        ("record_i64", 5),
-        ("record_f64", 6),
+        ("record_step", 0), // indices relative to end of user-provided type section
+        ("record_invalid", 1),
+        ("record_i32", 2),
+        ("record_f32", 3),
+        ("record_i64", 4),
+        ("record_f64", 5),
     ];
     const FUNC_SIGS: &'static [(&'static [EncoderValType], &'static [EncoderValType])] = &[
-        // 0: () -> () (type of func_placeholder)
-        (&[], &[]),
-        // 1: i32 -> i32
+        // 0: i32 -> i32
         (&[EncoderValType::I32], &[EncoderValType::I32]),
-        // 2: i32 -> ()
+        // 1: i32 -> ()
         (&[EncoderValType::I32], &[]),
-        // 3: (i32, i32) -> ()
+        // 2: (i32, i32) -> ()
         (&[EncoderValType::I32, EncoderValType::I32], &[]),
-        // 4: (f32, i32) -> ()
+        // 3: (f32, i32) -> ()
         (&[EncoderValType::F32, EncoderValType::I32], &[]),
-        // 5: (i64, i32) -> ()
+        // 4: (i64, i32) -> ()
         (&[EncoderValType::I64, EncoderValType::I32], &[]),
-        // 6: (f64, i32) -> ()
+        // 5: (f64, i32) -> ()
         (&[EncoderValType::F64, EncoderValType::I32], &[]),
     ];
 }
 
 #[derive(PartialEq, Eq)]
-enum HelperImportKind<'a> {
+pub enum HelperImportKind<'a> {
     Func {
         params: &'a [ValType],
         results: &'a [ValType],
     },
-    Global(wasmparser::GlobalType),
-    Memory(wasmparser::MemoryType),
+    Global(TextGlobalType<'a>),
+    Memory(TextMemoryType),
 }
 
 struct HelperImport<'a> {
@@ -75,6 +76,7 @@ struct HelperImport<'a> {
     kind: HelperImportKind<'a>,
     reason: &'static str,
 }
+
 const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
     (
         "draw",
@@ -126,8 +128,8 @@ const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
         &[
             HelperImport {
                 name: "num_samples",
-                kind: HelperImportKind::Global(wasmparser::GlobalType {
-                    content_type: ValType::I32,
+                kind: HelperImportKind::Global(TextGlobalType {
+                    ty: TextValType::I32,
                     mutable: false,
                     shared: false,
                 }),
@@ -135,11 +137,13 @@ const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
             },
             HelperImport {
                 name: "listen_memory",
-                kind: HelperImportKind::Memory(wasmparser::MemoryType {
-                    memory64: false,
+                kind: HelperImportKind::Memory(TextMemoryType {
+                    limits: TextLimits {
+                        is64: false,
+                        min: 1,
+                        max: None,
+                    },
                     shared: false,
-                    initial: 1,
-                    maximum: None,
                     page_size_log2: None,
                 }),
                 reason: "expected (memory 1)",
@@ -410,68 +414,42 @@ impl<'a> RawModule<'a> {
         wasm_bin: &'a [u8],
     ) -> Result<ValidModule<'a>> {
         let parser = wasmparser::Parser::new(0);
-        let import_lines = find_import_lines(editor);
         let mut validator = Validator::new_with_features(CODILLON_WASM_FEATURES);
+        let import_lines = find_import_lines(editor);
         let mut allocs = wasmparser::FuncValidatorAllocations::default();
 
-        /* Disable unlinkable imports */
+        /* Disable unlinkable function imports (other imports were already syntactically disabled) */
         let mut imports = Vec::new();
-        let placeholder_func_import = wasmparser::Import {
-            module: "codillon_debug",
-            name: "func_placeholder",
-            ty: wasmparser::TypeRef::Func(self.types.len() as u32), // empty type is first added type
-        };
-        let placeholder_global_import = wasmparser::Import {
-            module: "codillon_debug",
-            name: "global_placeholder",
-            ty: wasmparser::TypeRef::Global(wasmparser::GlobalType {
-                content_type: wasmparser::ValType::I32,
-                mutable: false,
-                shared: false,
-            }),
-        };
-        let placeholder_memory_import = wasmparser::Import {
-            module: "codillon_debug",
-            name: "memory_placeholder",
-            ty: wasmparser::TypeRef::Memory(wasmparser::MemoryType {
-                memory64: false,
-                shared: false,
-                initial: 0,
-                maximum: None,
-                page_size_log2: None,
-            }),
-        };
+
         for (import_idx, import @ wasmparser::Import { module, name, ty }) in
             self.imports.into_iter().enumerate()
         {
-            let (kind, placeholder) = match ty {
-                wasmparser::TypeRef::Func(type_idx) => {
-                    let func_type = &self.types[type_idx as usize];
-                    (
-                        &HelperImportKind::Func {
-                            params: func_type.params(),
-                            results: func_type.results(),
-                        },
-                        placeholder_func_import,
-                    )
-                }
-                wasmparser::TypeRef::Global(global_type) => (
-                    &HelperImportKind::Global(global_type),
-                    placeholder_global_import,
-                ),
-                wasmparser::TypeRef::Memory(memory_type) => (
-                    &HelperImportKind::Memory(memory_type),
-                    placeholder_memory_import,
-                ),
-                _ => unreachable!("unsupported import kind (forbidden syntactically)"),
+            let wasmparser::TypeRef::Func(type_idx) = ty else {
+                imports.push(import);
+                continue;
             };
-            match Self::check_import(module, name, kind) {
+
+            let func_type = &self.types[type_idx as usize];
+
+            match check_import(
+                module,
+                name,
+                &HelperImportKind::Func {
+                    params: func_type.params(),
+                    results: func_type.results(),
+                },
+            ) {
                 None => imports.push(import),
                 Some(reason) => {
                     editor.set_invalid(import_lines[import_idx], Some(reason));
-                    imports.push(placeholder);
+
+                    imports.push(wasmparser::Import {
+                        module: "codillon_debug",
+                        name: "func_placeholder",
+                        ty: wasmparser::TypeRef::Func(type_idx),
+                    });
                 }
-            };
+            }
         }
 
         let mut ret = ValidModule {
@@ -772,33 +750,33 @@ impl<'a> RawModule<'a> {
         assert!(&ops_reader.eof());
         Ok(())
     }
+}
 
-    fn check_import(
-        import_module: &str,
-        import_name: &str,
-        import_kind: &HelperImportKind,
-    ) -> Option<String> {
-        // Check if module name exists
-        for (module, components) in HELPER_IMPORTS {
-            if *module == import_module {
-                for HelperImport { name, kind, reason } in *components {
-                    // Check if component name exists
-                    if *name == import_name {
-                        // Check if function type matches
-                        return if import_kind == kind {
-                            None
-                        } else {
-                            Some(reason.to_string())
-                        };
-                    }
+pub fn check_import(
+    import_module: &str,
+    import_name: &str,
+    import_kind: &HelperImportKind,
+) -> Option<String> {
+    // Check if module name exists
+    for (module, components) in HELPER_IMPORTS {
+        if *module == import_module {
+            for HelperImport { name, kind, reason } in *components {
+                // Check if component name exists
+                if *name == import_name {
+                    // Check if function type matches
+                    return if import_kind == kind {
+                        None
+                    } else {
+                        Some(reason.to_string())
+                    };
                 }
-                return Some(format!(
-                    "function ‘{import_name}’ not found in module {module}"
-                ));
             }
+            return Some(format!(
+                "field ‘{import_name}’ not found in module {module}"
+            ));
         }
-        Some(format!("module ‘{import_module}’ not found"))
     }
+    Some(format!("module ‘{import_module}’ not found"))
 }
 
 #[derive(Default)]
@@ -2514,7 +2492,6 @@ pub(crate) mod tests {
     }
 
     const EXPECTED_TYPES: &str = r#"  (type (func))
-  (type (func))
   (type (func (param i32) (result i32)))
   (type (func (param i32)))
   (type (func (param i32 i32)))
@@ -2523,18 +2500,18 @@ pub(crate) mod tests {
   (type (func (param f64 i32)))
   (type (func (param i32)))
 "#;
-    const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 2)))
-  (import "codillon_debug" "record_invalid" (func (type 3)))
-  (import "codillon_debug" "record_i32" (func (type 4)))
-  (import "codillon_debug" "record_f32" (func (type 5)))
-  (import "codillon_debug" "record_i64" (func (type 6)))
-  (import "codillon_debug" "record_f64" (func (type 7)))
+    const EXPECTED_IMPORTS: &str = r#"  (import "codillon_debug" "record_step" (func (type 1)))
+  (import "codillon_debug" "record_invalid" (func (type 2)))
+  (import "codillon_debug" "record_i32" (func (type 3)))
+  (import "codillon_debug" "record_f32" (func (type 4)))
+  (import "codillon_debug" "record_i64" (func (type 5)))
+  (import "codillon_debug" "record_f64" (func (type 6)))
 "#;
 
     const EXPECTED_MAIN: &str = r#"  (export "main" (func 6))
 "#;
 
-    const EXPECTED_STEP: &str = r#"  (func (type 8) (param i32)
+    const EXPECTED_STEP: &str = r#"  (func (type 7) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -2649,7 +2626,7 @@ pub(crate) mod tests {
     call 7
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i64 i32) (result i64)
+                + r#"  (func (type 8) (param i64 i32) (result i64)
     local.get 0
     local.get 1
     call 4
@@ -2744,7 +2721,7 @@ pub(crate) mod tests {
     call 7
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i32 i32) (result i32)
+                + r#"  (func (type 8) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -2769,7 +2746,7 @@ pub(crate) mod tests {
             let expected = String::from("(module\n")
                 + EXPECTED_TYPES
                 + EXPECTED_IMPORTS
-                + r#"  (import "codillon_debug" "func_placeholder" (func (type 1)))
+                + r#"  (import "codillon_debug" "func_placeholder" (func (type 0)))
   (export "main" (func 7))
   (func (type 0)
     i32.const 6
@@ -2937,7 +2914,7 @@ pub(crate) mod tests {
     call 7
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i32 i32) (result i32)
+                + r#"  (func (type 8) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -2975,7 +2952,7 @@ pub(crate) mod tests {
     unreachable
   )
 "# + EXPECTED_STEP
-                + r#"  (func (type 9) (param i32 i32) (result i32)
+                + r#"  (func (type 8) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3000,7 +2977,6 @@ pub(crate) mod tests {
             let expected = String::from("(module\n")
                 + r#"  (type (func))
   (type (func (result i32 i32)))
-  (type (func))
   (type (func (param i32) (result i32)))
   (type (func (param i32)))
   (type (func (param i32 i32)))
@@ -3010,12 +2986,12 @@ pub(crate) mod tests {
   (type (func (param i32)))
   (type (func (param i32 i32 i32 i32) (result i32 i32)))
   (type (func (param i32 i32) (result i32)))
-  (import "codillon_debug" "record_step" (func (type 3)))
-  (import "codillon_debug" "record_invalid" (func (type 4)))
-  (import "codillon_debug" "record_i32" (func (type 5)))
-  (import "codillon_debug" "record_f32" (func (type 6)))
-  (import "codillon_debug" "record_i64" (func (type 7)))
-  (import "codillon_debug" "record_f64" (func (type 8)))
+  (import "codillon_debug" "record_step" (func (type 2)))
+  (import "codillon_debug" "record_invalid" (func (type 3)))
+  (import "codillon_debug" "record_i32" (func (type 4)))
+  (import "codillon_debug" "record_f32" (func (type 5)))
+  (import "codillon_debug" "record_i64" (func (type 6)))
+  (import "codillon_debug" "record_f64" (func (type 7)))
   (export "main" (func 6))
   (func (type 0)
     i32.const 0
@@ -3058,7 +3034,7 @@ pub(crate) mod tests {
     i32.const 6
     call 9
   )
-  (func (type 9) (param i32)
+  (func (type 8) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -3066,7 +3042,7 @@ pub(crate) mod tests {
       unreachable
     end
   )
-  (func (type 10) (param i32 i32 i32 i32) (result i32 i32)
+  (func (type 9) (param i32 i32 i32 i32) (result i32 i32)
     local.get 0
     local.get 2
     call 2
@@ -3076,7 +3052,7 @@ pub(crate) mod tests {
     local.get 0
     local.get 1
   )
-  (func (type 11) (param i32 i32) (result i32)
+  (func (type 10) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3134,7 +3110,6 @@ pub(crate) mod tests {
             let expected = String::from("(module\n")
                 + r#"  (type (func))
   (type (func (param i32)))
-  (type (func))
   (type (func (param i32) (result i32)))
   (type (func (param i32)))
   (type (func (param i32 i32)))
@@ -3143,12 +3118,12 @@ pub(crate) mod tests {
   (type (func (param f64 i32)))
   (type (func (param i32)))
   (type (func (param i32 i32) (result i32)))
-  (import "codillon_debug" "record_step" (func (type 3)))
-  (import "codillon_debug" "record_invalid" (func (type 4)))
-  (import "codillon_debug" "record_i32" (func (type 5)))
-  (import "codillon_debug" "record_f32" (func (type 6)))
-  (import "codillon_debug" "record_i64" (func (type 7)))
-  (import "codillon_debug" "record_f64" (func (type 8)))
+  (import "codillon_debug" "record_step" (func (type 2)))
+  (import "codillon_debug" "record_invalid" (func (type 3)))
+  (import "codillon_debug" "record_i32" (func (type 4)))
+  (import "codillon_debug" "record_f32" (func (type 5)))
+  (import "codillon_debug" "record_i64" (func (type 6)))
+  (import "codillon_debug" "record_f64" (func (type 7)))
   (export "main" (func 6))
   (func (type 0)
     i32.const 0
@@ -3170,7 +3145,7 @@ pub(crate) mod tests {
     i32.const 3
     call 7
   )
-  (func (type 9) (param i32)
+  (func (type 8) (param i32)
     local.get 0
     call 0
     i32.eqz
@@ -3178,7 +3153,7 @@ pub(crate) mod tests {
       unreachable
     end
   )
-  (func (type 10) (param i32 i32) (result i32)
+  (func (type 9) (param i32 i32) (result i32)
     local.get 0
     local.get 1
     call 2
@@ -3199,7 +3174,7 @@ pub(crate) mod tests {
             let expected = String::from("(module\n")
                 + EXPECTED_TYPES
                 + EXPECTED_IMPORTS
-                + r#"  (import "codillon_debug" "func_placeholder" (func (type 1)))
+                + r#"  (import "codillon_debug" "func_placeholder" (func (type 0)))
   (export "main" (func 7))
   (func (type 0)
     i32.const 1
@@ -3400,7 +3375,7 @@ pub(crate) mod tests {
                     .invalid
                     .as_ref()
                     .expect("nonexistent component name should be invalid"),
-                "function ‘not_point’ not found in module draw"
+                "field ‘not_point’ not found in module draw"
             );
         }
 
@@ -3530,14 +3505,14 @@ pub(crate) mod tests {
             editor.push_line("(import \"listen\" \"listen_memory\" (memory 2))");
             let _ = test_editor_flow(&mut editor)?;
             assert_eq!(
-                editor.lines[0].info.invalid.as_deref(),
-                Some("expected (global i32)"),
-                "num_samples with wrong mutability should be invalid"
+                editor.lines[0].info.kind,
+                LineKind::Malformed("expected (global i32)".to_string()),
+                "num_samples with wrong mutability should be rejected syntactically"
             );
             assert_eq!(
-                editor.lines[1].info.invalid.as_deref(),
-                Some("expected (memory 1)"),
-                "listen_memory with wrong size should be invalid"
+                editor.lines[1].info.kind,
+                LineKind::Malformed("expected (memory 1)".to_string()),
+                "listen_memory with wrong size should be rejected syntactically"
             );
         }
 


### PR DESCRIPTION
- Support "bad" func imports of arbitrary type (previously these led to a browser runtime error)
- Disable "bad" global/memory imports syntactically (previously these led to a browser runtime error because of a missing placeholder; I think we would need to provide a matching placeholder for each global/mem type)
- Don't forbid imports after another, multi-line, import
- Allow single-line func imports with params and results on same line

Fixes: #253