### PR TITLE
Fix: canvas extent bug

### DIFF
--- a/src/dom_canvas.rs
+++ b/src/dom_canvas.rs
@@ -58,7 +58,7 @@ impl DomCanvas {
                 Point(x, y) => {
                     let (xmin, xmax, ymin, ymax) = extent;
                     let pixel_x = (x - xmin) / (xmax - xmin) * WIDTH;
-                    let pixel_y = ymax * HEIGHT - (y - ymin) / (ymax - ymin) * HEIGHT;
+                    let pixel_y = HEIGHT - (y - ymin) / (ymax - ymin) * HEIGHT;
                     self.context.begin_path();
                     self.context
                         .arc(pixel_x, pixel_y, point_radius, 0.0, TAU)


### PR DESCRIPTION
### Bug
- Y position of points on canvas is erroneously scaled by ymax.

<img width="1019" height="813" alt="Screenshot 2026-06-17 at 3 23 03 PM" src="https://github.com/user-attachments/assets/a0563854-e4a7-463f-ac19-737d14fce056" />

### Fix
- Removed ymax scaling.

<img width="1022" height="728" alt="Screenshot 2026-06-17 at 3 25 09 PM" src="https://github.com/user-attachments/assets/5dfddec7-0d06-431a-9c50-82881154b0fb" />
