### PR TITLE
Fix: action history bug fix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+runner = "wasm-bindgen-test-runner"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,32 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --locked --all ${{ matrix.flags }}
 
+  test-browser:
+    name: Test browser
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chrome, firefox]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: taiki-e/install-action@9ba3ac3fd006a70c6e186a683577abc1ccf0ff3a
+      with:
+        tool: wasm-bindgen@0.2.122
+    - name: Webdrivers
+      run: |
+        if [ "${{ matrix.browser }}" = chrome ]; then
+          echo "CHROMEDRIVER=$CHROMEWEBDRIVER/chromedriver" >> "$GITHUB_ENV"
+        else
+          echo "GECKODRIVER=$GECKOWEBDRIVER/geckodriver" >> "$GITHUB_ENV"
+        fi
+    - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo test --target wasm32-unknown-unknown --locked
+    
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,6 @@ jobs:
           echo "GECKODRIVER=$GECKOWEBDRIVER/geckodriver" >> "$GITHUB_ENV"
         fi
     - run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo test --target wasm32-unknown-unknown --locked
-    
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,10 +352,11 @@ dependencies = [
  "thousands",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "wasm-encoder 0.251.0",
  "wasm-tools",
  "wasmparser 0.251.0",
- "wasmprinter 0.251.0",
+ "wasmprinter",
  "wasmtime",
  "wast",
  "wat",
@@ -426,27 +433,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
+checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
+checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
+checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -454,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
+checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -465,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
+checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -482,10 +489,13 @@ dependencies = [
  "hashbrown 0.17.1",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -493,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
+checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -506,24 +516,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
+checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
+checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
+checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -533,11 +543,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
+checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -545,15 +556,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
+checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
 
 [[package]]
 name = "cranelift-native"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
+checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -562,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
+checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
 
 [[package]]
 name = "crc32fast"
@@ -1284,13 +1295,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1353,12 +1363,9 @@ checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "memchr"
@@ -1385,6 +1392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,12 +1412,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1437,6 +1464,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "palette"
@@ -1599,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
+checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1611,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
+checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1715,6 +1748,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -1785,6 +1819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2166,9 +2209,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2179,6 +2222,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2206,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2219,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2229,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2239,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2252,29 +2305,51 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-compose"
-version = "0.248.0"
+name = "wasm-bindgen-test"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+checksum = "2a0d555ca874445df8d314f94f5c948a4e74e5418f332c89f660a3d8310a96f4"
 dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "log",
- "petgraph",
- "smallvec",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wat",
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eb68555b95bcea5e8cf4abe280b529049479fa995bfc23734af96a6aedc120"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31d56021e873866c968588ed85ccdf56db5c426e44afdb4618c39895104b920"
 
 [[package]]
 name = "wasm-compose"
@@ -2304,16 +2379,6 @@ checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -2434,14 +2499,14 @@ dependencies = [
  "serde_json",
  "tempfile",
  "termcolor",
- "wasm-compose 0.251.0",
+ "wasm-compose",
  "wasm-encoder 0.251.0",
  "wasm-metadata 0.251.0",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
  "wasmparser 0.251.0",
- "wasmprinter 0.251.0",
+ "wasmprinter",
  "wast",
  "wat",
  "wit-component 0.251.0",
@@ -2465,19 +2530,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
-dependencies = [
- "bitflags",
- "hashbrown 0.17.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
@@ -2487,17 +2539,6 @@ dependencies = [
  "indexmap 2.14.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -2513,9 +2554,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
+checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
 dependencies = [
  "addr2line 0.26.1",
  "async-trait",
@@ -2545,9 +2586,9 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasm-compose 0.248.0",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
+ "wasm-compose",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -2559,16 +2600,16 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
+checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
 dependencies = [
  "anyhow",
  "cpp_demangle 0.4.5",
@@ -2588,18 +2629,18 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter 0.248.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
+ "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef87f84d976e2f98a541eaf5837df0424e2039837fc20bd6cd4b4b5a322939c0"
+checksum = "438bc7dc45fb75297d75f79a9a0ce852345d13ebc6a6863f6f688f013836a9dd"
 dependencies = [
  "base64",
  "directories-next",
@@ -2617,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86991f201391afc1504e4fc363dc29b66f92af0287b4ac2efc3c0b0c19435eeb"
+checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2627,20 +2668,20 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.248.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47fda091250d7ab839ea51e4d98190b6eee37e9de4ab2462e8fe8465369c1986"
+checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -2650,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
+checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2668,7 +2709,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.248.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -2677,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
+checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2692,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
+checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -2704,9 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
+checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2716,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
+checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2729,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
+checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2739,33 +2780,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
-dependencies = [
- "cranelift-codegen",
- "gimli 0.33.0",
- "log",
- "object 0.39.1",
- "target-lexicon",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "45.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce382df367ad2a2d48e139b191dbca3329f7232a43057dc9efc889dac54f1b0b"
+checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.248.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -2793,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2831,25 +2855,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "45.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli 0.33.0",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows-link"
@@ -3091,25 +3096,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
-dependencies = [
- "anyhow",
- "hashbrown 0.17.1",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.248.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,8 @@ arrayvec = "0.7.6"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
-wasmtime = "45.0.0"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+wasmtime="46.0.1"
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.76"

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 1. Install Rust (https://rustup.rs/). Restart your terminal.
 2. Run `cargo install trunk`
 3. Run `rustup target add wasm32-unknown-unknown`
-4. Use `trunk serve` to serve the website, and use `cargo test` to run unit tests
+4. Use `trunk serve` to serve the website, `cargo test` to run unit tests, and `cargo test --target wasm32-unknown-unknown` to run headless browser tests

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1410,7 +1410,7 @@ mod browser_tests {
 
         const EMPTY_FUNCTION: &str = "(func\n\n)\n";
         const BLOCK_INSERTED_FUNCTION: &str = "(func\nblock\nend\n)\n";
-        // Undo and redo preserves added block curtesy end
+        // Undo and redo preserves added block courtesy end
         {
             set_contents(editor, &EMPTY_FUNCTION.lines().collect::<Vec<_>>());
             assert_eq!(editor.buffer_as_text(), EMPTY_FUNCTION);
@@ -1429,7 +1429,7 @@ mod browser_tests {
             assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);
         }
 
-        // Undo and redo preserves deleted block curtesy end
+        // Undo and redo preserves deleted block courtesy end
         {
             set_contents(editor, &BLOCK_INSERTED_FUNCTION.lines().collect::<Vec<_>>());
             assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -454,29 +454,29 @@ impl Editor {
     }
 
     // Replace a given range (currently within a single line) with new text
-    fn replace_range(&mut self, target_range: &impl RangeLike, new_str: &str) -> Result<()> {
+    fn handle_edit(&mut self, target_range: &impl RangeLike, new_str: &str) -> Result<()> {
         if new_str.chars().any(|x| x.is_control() && x != '\n') {
             bail!("unhandled control char in input");
         }
 
         let saved_selection = self.get_lines_and_positions(&get_selection())?; // in case we need to revert
         let target = self.get_lines_and_positions(target_range)?;
-        self.replace_position_range(target, saved_selection, new_str, true)
+        self.replace_range(&target, &saved_selection, new_str, true)
     }
 
-    fn replace_position_range(
+    fn replace_range(
         &mut self,
-        target: PositionRange,
-        saved_selection: PositionRange,
+        target: &PositionRange,
+        saved_selection: &PositionRange,
         new_str: &str,
-        record: bool,
+        record_for_undo: bool,
     ) -> Result<()> {
         let PositionRange {
             start_line,
             start_pos,
             end_line,
             end_pos,
-        } = target;
+        } = *target;
 
         let mut backup = Vec::new();
         for i in start_line..end_line + 1 {
@@ -625,7 +625,7 @@ impl Editor {
             Ok(()) => {
                 self.line(fixup_line).set_cursor_position(new_cursor_pos)?;
                 // Store new edit
-                if record {
+                if record_for_undo {
                     let mut new_lines = Vec::new();
                     for i in start_line..=fixup_line {
                         new_lines.push(self.line(i).suffix(Position::begin())?);
@@ -634,7 +634,7 @@ impl Editor {
                         start_line,
                         old_lines: backup,
                         new_lines,
-                        selection_before: saved_selection,
+                        selection_before: saved_selection.clone(),
                         selection_after: PositionRange {
                             start_line: fixup_line,
                             start_pos: new_cursor_pos,
@@ -680,8 +680,8 @@ impl Editor {
         let target_range = ev.get_first_target_range()?;
 
         match &ev.input_type() as &str {
-            "insertText" => self.replace_range(&target_range, &ev.data().context("no data")?),
-            "insertFromPaste" => self.replace_range(
+            "insertText" => self.handle_edit(&target_range, &ev.data().context("no data")?),
+            "insertFromPaste" => self.handle_edit(
                 &target_range,
                 &self.input_filter.replace_all(
                     &ev.data_transfer()
@@ -692,9 +692,9 @@ impl Editor {
                 ),
             ),
             "deleteContentBackward" | "deleteContentForward" | "deleteByCut" => {
-                self.replace_range(&target_range, "")
+                self.handle_edit(&target_range, "")
             }
-            "insertParagraph" | "insertLineBreak" => self.replace_range(&target_range, "\n"),
+            "insertParagraph" | "insertLineBreak" => self.handle_edit(&target_range, "\n"),
             _ => bail!(format!(
                 "unhandled input type {}, data {:?}",
                 ev.input_type(),
@@ -1163,7 +1163,7 @@ impl Editor {
             end_pos: self.line(end_line).end_position(),
         };
         let new_str = insert_lines.join("\n");
-        self.replace_position_range(target, selection_after.clone(), &new_str, false)?;
+        self.replace_range(&target, selection_after, &new_str, false)?;
         let document_length = self.text().len().saturating_sub(1);
         let start_index = min(selection_after.start_line, document_length);
         let end_index = min(selection_after.end_line, document_length);
@@ -1217,7 +1217,7 @@ impl Editor {
             )?;
 
             if pos.in_instr && pos.offset < accepted.len() {
-                self.replace_range(&selection, &accepted[pos.offset..])?;
+                self.handle_edit(&selection, &accepted[pos.offset..])?;
             }
         }
         self.autocomplete_mut().update("");
@@ -1419,7 +1419,7 @@ mod browser_tests {
                 .line(1)
                 .position_to_node_and_weboffset(Position::begin())?;
             set_selection_range(&node, offset, &node, offset);
-            editor.replace_range(&get_selection(), "block")?;
+            editor.handle_edit(&get_selection(), "block")?;
             assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);
 
             editor.undo()?;
@@ -1441,7 +1441,7 @@ mod browser_tests {
                 .line(1)
                 .position_to_node_and_weboffset(editor.line(1).end_position())?;
             set_selection_range(&start_node, start_offset, &end_node, end_offset);
-            editor.replace_range(&get_selection(), "")?;
+            editor.handle_edit(&get_selection(), "")?;
             assert_eq!(editor.buffer_as_text(), EMPTY_FUNCTION);
 
             editor.undo()?;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -458,13 +458,23 @@ impl Editor {
         }
 
         let saved_selection = self.get_lines_and_positions(&get_selection())?; // in case we need to revert
+        let target = self.get_lines_and_positions(target_range)?;
+        self.replace_position_range(target, saved_selection, new_str, true)
+    }
 
+    fn replace_position_range(
+        &mut self,
+        target: PositionRange,
+        saved_selection: PositionRange,
+        new_str: &str,
+        record: bool,
+    ) -> Result<()> {
         let PositionRange {
             start_line,
             start_pos,
             end_line,
             end_pos,
-        } = self.get_lines_and_positions(target_range)?;
+        } = target;
 
         let mut backup = Vec::new();
         for i in start_line..end_line + 1 {
@@ -612,12 +622,12 @@ impl Editor {
         match self.on_change() {
             Ok(()) => {
                 self.line(fixup_line).set_cursor_position(new_cursor_pos)?;
-                let mut new_lines = Vec::new();
-                for i in start_line..=fixup_line {
-                    new_lines.push(self.line(i).suffix(Position::begin())?);
-                }
                 // Store new edit
-                {
+                if record {
+                    let mut new_lines = Vec::new();
+                    for i in start_line..=fixup_line {
+                        new_lines.push(self.line(i).suffix(Position::begin())?);
+                    }
                     self.action_history.store_edit(Edit {
                         start_line,
                         old_lines: backup,
@@ -1139,27 +1149,20 @@ impl Editor {
         insert_lines: &[String],
         selection_after: &PositionRange,
     ) -> Result<()> {
-        let mut document_length = self.text().len();
-        if start_line > document_length {
+        let document_length = self.text().len();
+        if start_line >= document_length {
             bail!("start_line {start_line} out of range");
         }
-        // Removing ending
-        let end = min(
-            start_line
-                .checked_add(remove_len)
-                .unwrap_or(document_length),
-            self.text().len(),
-        );
-        if end > start_line {
-            self.text_mut().remove_range(start_line, end);
-        }
-        // Add new lines
-        for (index, value) in insert_lines.iter().enumerate() {
-            let newline = CodeLine::new(value, &self.factory);
-            self.text_mut().insert(start_line + index, newline);
-        }
-        self.on_change()?;
-        document_length = self.text().len().saturating_sub(1);
+        let end_line = min(start_line + remove_len, document_length) - 1;
+        let target = PositionRange {
+            start_line,
+            start_pos: Position::begin(),
+            end_line,
+            end_pos: self.line(end_line).end_position(),
+        };
+        let new_str = insert_lines.join("\n");
+        self.replace_position_range(target, selection_after.clone(), &new_str, false)?;
+        let document_length = self.text().len().saturating_sub(1);
         let start_index = min(selection_after.start_line, document_length);
         let end_index = min(selection_after.end_line, document_length);
         // Restore caret position

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,8 +9,8 @@ use crate::{
     dom_vec::DomVec,
     graphics::{DomImage, FractionInfo},
     jet::{
-        AccessToken, Component, ControlHandlers, ElementFactory, InputEventHandle, NodeRef,
-        RangeLike, ReactiveComponent, StorageHandle, WebOffset, WindowHandle, WithElement,
+        AccessToken, Component, ControlHandlers, DocumentHandle, ElementFactory, InputEventHandle,
+        NodeRef, RangeLike, ReactiveComponent, StorageHandle, WebOffset, WindowHandle, WithElement,
         compare_document_position, get_selection, now_ms, set_selection_range,
     },
     line::{Activity, CodeLine, LineInfo, Position, PositionRange},
@@ -38,6 +38,8 @@ use std::{
 use wasm_bindgen::{closure::Closure, prelude::ScopedClosure};
 use web_sys::{BeforeUnloadEvent, HtmlDivElement, console::log_1};
 
+pub type Body = DomStruct<(EditorHolder, ()), web_sys::HtmlBodyElement>;
+pub type Document = DocumentHandle<Body>;
 type TextType = DomVec<CodeLine, HtmlDivElement>;
 type ComponentType = DomStruct<
     (
@@ -1376,5 +1378,81 @@ impl Editor {
         self.push_line("i32.add");
         self.push_line("drop");
         self.push_line(")");
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod browser_tests {
+    use super::*;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn set_contents(editor: &mut Editor, lines: &[&str]) {
+        let line_count = editor.text().len();
+        editor.text_mut().remove_range(0, line_count);
+        for line in lines {
+            editor.push_line(line);
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn action_history_courtesy_end() -> Result<()> {
+        // Need to save a copy of harness body to restore
+        let harness_document = web_sys::window().unwrap().document().unwrap();
+        let harness_body = harness_document.body().expect("harness body");
+
+        let mut document = Document::default();
+        let factory = document.element_factory();
+        let editor = EditorHolder::new(factory.clone())?;
+        let editor_holder = EditorHolder(Rc::clone(&editor.0));
+        document.set_body(Body::new((editor, ()), factory.body()));
+        let editor: &mut Editor = &mut editor_holder.borrow_mut();
+
+        const EMPTY_FUNCTION: &str = "(func\n\n)\n";
+        const BLOCK_INSERTED_FUNCTION: &str = "(func\nblock\nend\n)\n";
+        // Undo and redo preserves added block curtesy end
+        {
+            set_contents(editor, &EMPTY_FUNCTION.lines().collect::<Vec<_>>());
+            assert_eq!(editor.buffer_as_text(), EMPTY_FUNCTION);
+
+            let (node, offset) = editor
+                .line(1)
+                .position_to_node_and_weboffset(Position::begin())?;
+            set_selection_range(&node, offset, &node, offset);
+            editor.replace_range(&get_selection(), "block")?;
+            assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);
+
+            editor.undo()?;
+            assert_eq!(editor.buffer_as_text(), EMPTY_FUNCTION);
+
+            editor.redo()?;
+            assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);
+        }
+
+        // Undo and redo preserves deleted block curtesy end
+        {
+            set_contents(editor, &BLOCK_INSERTED_FUNCTION.lines().collect::<Vec<_>>());
+            assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);
+
+            let (start_node, start_offset) = editor
+                .line(1)
+                .position_to_node_and_weboffset(Position::begin())?;
+            let (end_node, end_offset) = editor
+                .line(1)
+                .position_to_node_and_weboffset(editor.line(1).end_position())?;
+            set_selection_range(&start_node, start_offset, &end_node, end_offset);
+            editor.replace_range(&get_selection(), "")?;
+            assert_eq!(editor.buffer_as_text(), EMPTY_FUNCTION);
+
+            editor.undo()?;
+            assert_eq!(editor.buffer_as_text(), BLOCK_INSERTED_FUNCTION);
+
+            editor.redo()?;
+            assert_eq!(editor.buffer_as_text(), EMPTY_FUNCTION);
+        }
+
+        // restore test harness body
+        harness_document.set_body(Some(&harness_body));
+        Ok(())
     }
 }

--- a/src/line.rs
+++ b/src/line.rs
@@ -200,7 +200,7 @@ impl Position {
         }
     }
 }
-
+#[derive(Clone)]
 pub struct PositionRange {
     pub start_line: usize,
     pub start_pos: Position,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
-use codillon::{dom_struct::DomStruct, editor::EditorHolder, jet::DocumentHandle};
+use codillon::editor::{Body, Document, EditorHolder};
 use std::cell::RefCell;
-
-type Body = DomStruct<(EditorHolder, ()), web_sys::HtmlBodyElement>;
-type Document = DocumentHandle<Body>;
 
 thread_local! {
     static DOCUMENT: RefCell<Document> = Document::default().into();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2427,7 +2427,6 @@ impl Tween {
     }
 }
 
-#[cfg(test)]
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2428,6 +2428,7 @@ impl Tween {
 }
 
 #[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {
     use super::*;
     use crate::debug::{


### PR DESCRIPTION
### Bug
- Undoes and redoes don't track "courtesy ends" as derived changes.

https://github.com/user-attachments/assets/96528bd6-1407-4e95-9df2-ce1b519d151a


### Fix
- apply_selection() uses replace_position_range() to rederive "courtesy ends."


https://github.com/user-attachments/assets/c5080abf-c493-4c4a-bb16-7226169e7876

### PR Description
- Added headless browser tests to ensure that undo and redo restore and delete the derived courtesy ends
- Added CI Jobs to run the headless tests in Chrome and Firefox