### PR TITLE
Refactor import handling

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -103,22 +103,14 @@ impl RunLog {
 
     pub fn wasm_step(&self, line_num: u32) -> bool {
         use TerminationType::*;
-        if self.termination_type() == HitBadImport && self.step_count() > 0 {
-            self.with_completed_step(self.step_count() - 1, |completed| {
-                self.with_current_step_mut(|current| {
-                    current.line_num = completed.line_num;
-                })
-            });
-        } else {
-            self.with_current_step_mut(|step| step.line_num = line_num);
-        }
 
+        self.with_current_step_mut(|step| step.line_num = line_num);
         self.commit_step();
 
         match self.termination_type() {
             Running => (),
             TooManySteps => panic!("execution unexpectedly continued after TooManySteps"),
-            HitInvalid | HitBadImport => return false,
+            HitInvalid => return false,
             Error => panic!("execution unexpectedly continued after Error"),
             Success => panic!("execution unexpectedly continued after Success"),
         }
@@ -154,7 +146,6 @@ impl RunLog {
                 TerminationType::Running => self.set_termination_type(TerminationType::Success),
                 TerminationType::TooManySteps
                 | TerminationType::HitInvalid
-                | TerminationType::HitBadImport
                 | TerminationType::Success
                 | TerminationType::Error => {
                     unreachable!("success after other result");
@@ -173,9 +164,7 @@ impl RunLog {
                     self.set_termination_type(TerminationType::Error);
                     self.set_error_string(err);
                 }
-                TerminationType::HitInvalid
-                | TerminationType::HitBadImport
-                | TerminationType::TooManySteps => {} // error is expected
+                TerminationType::HitInvalid | TerminationType::TooManySteps => {} // error is expected
                 TerminationType::Success | TerminationType::Error => {
                     unreachable!("error after other result");
                 }
@@ -309,7 +298,6 @@ pub enum TerminationType {
     Running,
     TooManySteps,
     HitInvalid,
-    HitBadImport,
     Error,
     Success,
 }
@@ -542,11 +530,6 @@ fn make_imports() -> Result<Object, JsValue> {
         let record_invalid: ScopedClosure<'_, dyn Fn()> =
             Closure::new(|| RUN_LOG.with(|r| r.set_termination_type(TerminationType::HitInvalid)));
         register_closure(&codillon_debug, "record_invalid", record_invalid);
-
-        let func_placeholder: ScopedClosure<'_, dyn Fn()> = Closure::new(|| {
-            RUN_LOG.with(|r| r.set_termination_type(TerminationType::HitBadImport))
-        });
-        register_closure(&codillon_debug, "func_placeholder", func_placeholder);
 
         create_closure_record_operations(&codillon_debug);
         create_closure_frame_operations(&codillon_debug);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -287,11 +287,6 @@ impl Editor {
                     error: Some(msg),
                     ..
                 } => (*line_num, msg),
-                ExecutionStatus {
-                    line_num: Some(line_num),
-                    termination: TerminationType::HitBadImport,
-                    ..
-                } => (*line_num, "called unknown import"),
                 _ => return None,
             })
         }

--- a/src/line.rs
+++ b/src/line.rs
@@ -9,7 +9,7 @@ use crate::{
     graphics::indent_px,
     jet::{AccessToken, Component, ElementFactory, NodeRef, WithElement, set_selection_range},
     symbolic::{LineSymbols, parse_line_symbols},
-    syntax::{InstrKind, LineKind, ModulePart, SyntheticWasm, parse_line},
+    syntax::{FuncPart, InstrKind, LineKind, ModulePart, SyntheticWasm, parse_line},
     utils::find_comment,
 };
 use anyhow::{Result, bail};
@@ -56,7 +56,7 @@ impl Default for LineInfo {
     fn default() -> Self {
         let ret = Self {
             id: NEXT_LINE_ID.get(),
-            kind: Default::default(),
+            kind: LineKind::Empty,
             active: Default::default(),
             indent: None,
             synthetic_before: Default::default(),
@@ -97,22 +97,22 @@ impl LineInfo {
         let mut initial = 0;
         for part in &self.synthetic_before.module_field_syntax {
             match part {
-                ModulePart::LParen => initial += 1,
-                ModulePart::RParen => initial -= 1,
+                FuncPart::LParen => initial += 1,
+                FuncPart::RParen => initial -= 1,
                 _ => {}
             }
         }
 
         let mut rest = 0;
         if self.is_active()
-            && let LineKind::Other(parts) = &self.kind
+            && let LineKind::Other(ModulePart::Func(parts)) = &self.kind
         {
             let mut first_letter = true;
             for part in parts {
                 match part {
-                    ModulePart::RParen if first_letter => initial -= 1,
-                    ModulePart::RParen => rest -= 1,
-                    ModulePart::LParen => rest += 1,
+                    FuncPart::RParen if first_letter => initial -= 1,
+                    FuncPart::RParen => rest -= 1,
+                    FuncPart::LParen => rest += 1,
                     _ => {}
                 }
                 first_letter = false;

--- a/src/symbolic.rs
+++ b/src/symbolic.rs
@@ -3,15 +3,16 @@
 use std::collections::HashSet;
 use wast::{
     core::{
-        ElemPayload, Export, ExportKind, Expression, Func, FuncKind, FunctionType, Global,
-        GlobalKind, HeapType, ImportItems, Imports, Instruction, ItemKind, ItemSig, Local, Memory,
-        ModuleField, Table, TableKind, ValType,
+        ElemPayload, Export, ExportKind, Expression, Func, FunctionType, Global, GlobalKind,
+        HeapType, ImportItems, Imports, InlineExport, Instruction, ItemKind, ItemSig, Local,
+        LocalParser, Memory, Table, TableKind, ValType,
     },
-    parser::{self, ParseBuffer},
-    token::Index,
+    kw,
+    parser::{self, Parse, ParseBuffer, Parser},
+    token::{Id, Index},
 };
 
-use crate::syntax::{LineKind, ModulePart};
+use crate::syntax::{CodillonParam, CodillonResult, ImportKind, LineKind, ModulePart};
 
 #[derive(Clone, Debug, PartialEq)]
 enum IndexSpace {
@@ -406,6 +407,24 @@ impl<'a> From<ValType<'a>> for LineSymbols {
     }
 }
 
+impl<'a> From<LocalParser<'a>> for LineSymbols {
+    fn from(p: LocalParser) -> Self {
+        let mut line_symbols = LineSymbols::default();
+
+        for Local { id, ty, .. } in p.locals {
+            if let Some(id) = id {
+                line_symbols
+                    .defines
+                    .push(SymbolRef::new(id.name(), IndexSpace::Local));
+            }
+
+            line_symbols.merge(ty.into());
+        }
+
+        line_symbols
+    }
+}
+
 impl<'a> From<FunctionType<'a>> for LineSymbols {
     fn from(ft: FunctionType) -> Self {
         let mut line_symbols = LineSymbols::default();
@@ -576,72 +595,84 @@ impl<'a> From<Memory<'a>> for LineSymbols {
     }
 }
 
+struct Parened<T>(T);
+
+impl<'a, T: Parse<'a>> Parse<'a> for Parened<T> {
+    fn parse(parser: Parser<'a>) -> Result<Self, wast::Error> {
+        Ok(Self(parser.parens(T::parse)?))
+    }
+}
+
+impl<T: Into<LineSymbols>> From<Parened<T>> for LineSymbols {
+    fn from(val: Parened<T>) -> Self {
+        val.0.into()
+    }
+}
+
+struct FuncDefs(LineSymbols);
+impl<'a> Parse<'a> for FuncDefs {
+    fn parse(parser: Parser<'a>) -> Result<Self, wast::Error> {
+        let mut syms = LineSymbols::default();
+        while !parser.is_empty() || parser.step(|c| Ok((c.peek_rparen()?, c)))? {
+            if parser.peek::<kw::func>()? {
+                parser.parse::<kw::func>()?;
+            } else if parser.peek::<Id>()? {
+                syms.defines.push(SymbolRef::new(
+                    parser.parse::<Id>()?.name(),
+                    IndexSpace::Func,
+                ));
+            } else if parser.peek::<InlineExport>()? {
+                parser.parse::<InlineExport>()?;
+            } else if parser.peek2::<kw::param>()? {
+                syms.merge(parser.parse::<CodillonParam>()?.0.into());
+            } else if parser.peek2::<kw::result>()? {
+                syms.merge(parser.parse::<CodillonResult>()?.0.into());
+            } else if parser.peek2::<kw::local>()? {
+                syms.merge(parser.parse::<Parened<LocalParser>>()?.into());
+            } else if parser.step(|cursor| match cursor.lparen()? {
+                Some(rest) => Ok((true, rest)),
+                None => Ok((false, cursor)),
+            })? || parser.step(|cursor| match cursor.rparen()? {
+                Some(rest) => Ok((true, rest)),
+                None => Ok((false, cursor)),
+            })? {
+            } else {
+                panic!("unexpected token")
+            }
+        }
+        Ok(Self(syms))
+    }
+}
+
 // Assume kind correctly reflects the line's kind
 pub fn parse_line_symbols(s: &str, kind: &LineKind) -> LineSymbols {
+    let buf = ParseBuffer::new(s).unwrap();
     match kind {
-        LineKind::Instr(_) => {
-            let Ok(buf) = ParseBuffer::new(s) else {
-                return LineSymbols::default();
-            };
-            parser::parse::<Instruction>(&buf)
-                .map(Into::into)
-                .unwrap_or_default()
-        }
-        LineKind::Other(module_parts) if !module_parts.is_empty() && s.len() > 1 => {
-            // Line is non-function module part
-            let Ok(buf) = ParseBuffer::new(&s[1..s.len() - 1]) else {
-                return LineSymbols::default();
-            };
-            if let Ok(field) = parser::parse::<ModuleField>(&buf) {
-                match field {
-                    ModuleField::Export(e) => return e.into(),
-                    ModuleField::Import(i) => return i.into(),
-                    ModuleField::Global(g) => return g.into(),
-                    ModuleField::Table(t) => return t.into(),
-                    ModuleField::Memory(m) => return m.into(),
-                    _ => {}
+        LineKind::Instr(_) => parser::parse::<Instruction>(&buf)
+            .map(Into::into)
+            .unwrap_or_default(),
+        LineKind::Other(part) => match part {
+            ModulePart::Export => parser::parse::<Parened<Export>>(&buf).unwrap().into(),
+            ModulePart::Import(kind) => match kind {
+                ImportKind::Import => parser::parse::<Parened<Imports>>(&buf).unwrap().into(),
+                ImportKind::InlineFunc => {
+                    if let Some(name) = parser::parse::<Parened<Func>>(&buf).unwrap().0.id {
+                        LineSymbols {
+                            defines: vec![SymbolRef::new(name.name(), IndexSpace::Func)],
+                            consumes: vec![],
+                        }
+                    } else {
+                        LineSymbols::default()
+                    }
                 }
-            }
-
-            // Line is made up of function segments
-            let mut wrapped_s = match module_parts[0] {
-                ModulePart::FuncKeyword => s.to_string(),
-                ModulePart::LParen => s[1..].to_string(),
-                _ => format!("func {s}"),
-            };
-            if matches!(module_parts.last(), Some(ModulePart::RParen)) {
-                wrapped_s = wrapped_s
-                    .strip_suffix(')')
-                    .unwrap_or(&wrapped_s)
-                    .to_string();
-            }
-
-            let Ok(wrapped_buf) = ParseBuffer::new(&wrapped_s) else {
-                return LineSymbols::default();
-            };
-            let Ok(func) = parser::parse::<Func>(&wrapped_buf) else {
-                return LineSymbols::default();
-            };
-
-            let mut line_symbols = LineSymbols::default();
-            // Id
-            if let Some(id) = func.id {
-                line_symbols
-                    .defines
-                    .push(SymbolRef::new(id.name(), IndexSpace::Func));
-            }
-            // Param & Result
-            if let Some(ft) = func.ty.inline {
-                line_symbols.merge(ft.into());
-            }
-            // Local
-            if let FuncKind::Inline { locals, .. } = func.kind {
-                for local in locals {
-                    line_symbols.merge(local.into());
-                }
-            }
-            line_symbols
-        }
+                ImportKind::InlineMemory => parser::parse::<Parened<Memory>>(&buf).unwrap().into(),
+                ImportKind::InlineGlobal => parser::parse::<Parened<Global>>(&buf).unwrap().into(),
+            },
+            ModulePart::Global => parser::parse::<Parened<Global>>(&buf).unwrap().into(),
+            ModulePart::Table => parser::parse::<Parened<Table>>(&buf).unwrap().into(),
+            ModulePart::Memory => parser::parse::<Parened<Memory>>(&buf).unwrap().into(),
+            ModulePart::Func(_) => parser::parse::<FuncDefs>(&buf).unwrap().0,
+        },
         _ => LineSymbols::default(),
     }
 }
@@ -770,11 +801,6 @@ mod tests {
         assert_eq!(symbols.defines[0].space, IndexSpace::Mem);
         assert!(symbols.consumes.is_empty());
 
-        line = "(memory $mem 1 2) (func)";
-        symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
-        assert!(symbols.defines.is_empty());
-        assert!(symbols.consumes.is_empty());
-
         line = "(export \"foo\" (func $myfunc))";
         symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
         assert!(symbols.defines.is_empty());
@@ -782,7 +808,7 @@ mod tests {
         assert_eq!(symbols.consumes[0].name, "myfunc");
         assert_eq!(symbols.consumes[0].space, IndexSpace::Func);
 
-        line = "(import \"env\" \"fn\"  (func $f (param $p i32)))";
+        line = "(import \"draw\" \"set_radius\"  (func $f (param $p f64)))";
         symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
         assert_eq!(symbols.defines.len(), 2);
         assert_eq!(symbols.defines[0].name, "f");
@@ -791,14 +817,16 @@ mod tests {
         assert_eq!(symbols.defines[1].space, IndexSpace::Local);
         assert!(symbols.consumes.is_empty());
 
-        line = "(import \"env\" \"fn\"  (func $f (type $t)))";
-        symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
-        assert_eq!(symbols.defines.len(), 1);
-        assert_eq!(symbols.defines[0].name, "f");
-        assert_eq!(symbols.defines[0].space, IndexSpace::Func);
-        assert_eq!(symbols.consumes.len(), 1);
-        assert_eq!(symbols.consumes[0].name, "t");
-        assert_eq!(symbols.consumes[0].space, IndexSpace::Type);
+        /* type index not supported
+                line = "(import \"env\" \"fn\"  (func $f (type $t)))";
+                symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
+                assert_eq!(symbols.defines.len(), 1);
+                assert_eq!(symbols.defines[0].name, "f");
+                assert_eq!(symbols.defines[0].space, IndexSpace::Func);
+                assert_eq!(symbols.consumes.len(), 1);
+                assert_eq!(symbols.consumes[0].name, "t");
+                assert_eq!(symbols.consumes[0].space, IndexSpace::Type);
+        */
 
         line = "(func $f (param $p i32) (result (ref $ft)) (local $l i64))";
         symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
@@ -834,9 +862,7 @@ mod tests {
         assert!(symbols.consumes.is_empty());
 
         line = "(import \"\" \"\") (local $l f32)";
-        symbols = parse_line_symbols(line, &parse::<LineKind>(&ParseBuffer::new(line)?)?);
-        assert!(symbols.defines.is_empty());
-        assert!(symbols.consumes.is_empty());
+        assert!(parse::<LineKind>(&ParseBuffer::new(line)?).is_err());
 
         Ok(())
     }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,18 +1,20 @@
 // Structures and utilities to support multi-function/multi-module text buffers.
 
-use crate::line::LineInfo;
-use crate::symbolic::{
-    ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
-    symbols_resolved,
+use crate::{
+    line::LineInfo,
+    symbolic::{
+        ModuleIdentifiers, collect_label_symbol, collect_local_symbols, collect_module_symbols,
+        symbols_resolved,
+    },
+    utils::{HelperImportKind, check_import},
 };
-use crate::utils::{HelperImportKind, check_import};
 use anyhow::Result;
 use std::collections::HashSet;
 use wast::{
     Error,
     core::{
-        Export, Global, Imports, InlineExport, InlineImport, Instruction, ItemKind, Limits,
-        LocalParser, Memory, MemoryType, Table, ValType,
+        Export, Func, FuncKind, FunctionType, Global, Imports, InlineExport, InlineImport,
+        Instruction, ItemKind, Limits, LocalParser, Memory, MemoryType, Table, TypeUse, ValType,
     },
     kw,
     parser::{self, Cursor, Parse, ParseBuffer, Parser, Peek},
@@ -30,26 +32,38 @@ pub enum InstrKind {
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum ModulePart {
-    LParen,
-    RParen,
+pub enum FuncPart {
     FuncKeyword,
     Id,
-    Export,
-    Import,
     InlineExport,
-    InlineImport,
     Param,
     Result,
     Local(usize), // number of locals declared
-    Global,
-    Table,
-    Memory,
+    LParen,
+    RParen,
 }
 
-impl From<ModulePart> for &'static str {
-    fn from(val: ModulePart) -> &'static str {
-        use ModulePart::*;
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ImportKind {
+    Import,
+    InlineMemory,
+    InlineGlobal,
+    InlineFunc,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ModulePart {
+    Export,
+    Import(ImportKind),
+    Memory,
+    Table,
+    Global,
+    Func(Vec<FuncPart>),
+}
+
+impl From<FuncPart> for &'static str {
+    fn from(val: FuncPart) -> &'static str {
+        use FuncPart::*;
         match val {
             LParen => "(",
             RParen => ")",
@@ -59,72 +73,11 @@ impl From<ModulePart> for &'static str {
     }
 }
 
-impl From<kw::func> for ModulePart {
-    fn from(_: kw::func) -> Self {
-        ModulePart::FuncKeyword
-    }
-}
-
-impl<'a> From<Id<'a>> for ModulePart {
-    fn from(_: Id) -> Self {
-        ModulePart::Id
-    }
-}
-
-impl<'a> From<InlineImport<'a>> for ModulePart {
-    fn from(_: InlineImport) -> Self {
-        ModulePart::InlineImport
-    }
-}
-
-impl<'a> From<Imports<'a>> for ModulePart {
-    fn from(_: Imports) -> Self {
-        ModulePart::Import
-    }
-}
-
-impl<'a> From<InlineExport<'a>> for ModulePart {
-    fn from(_: InlineExport) -> Self {
-        ModulePart::InlineExport
-    }
-}
-
-impl<'a> From<Export<'a>> for ModulePart {
-    fn from(_: Export) -> Self {
-        ModulePart::Export
-    }
-}
-
-impl<'a> From<LocalParser<'a>> for ModulePart {
-    fn from(parser: LocalParser) -> Self {
-        ModulePart::Local(parser.locals.len())
-    }
-}
-
-impl<'a> From<Memory<'a>> for ModulePart {
-    fn from(_: Memory) -> Self {
-        ModulePart::Memory
-    }
-}
-
-impl<'a> From<Global<'a>> for ModulePart {
-    fn from(_: Global) -> Self {
-        ModulePart::Global
-    }
-}
-
-impl<'a> From<Table<'a>> for ModulePart {
-    fn from(_: Table) -> Self {
-        ModulePart::Table
-    }
-}
-
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LineKind {
-    #[default]
     Empty,
     Instr(InstrKind),
-    Other(Vec<ModulePart>),
+    Other(ModulePart),
     Malformed(String), // explanation
 }
 
@@ -199,78 +152,48 @@ impl From<Error> for LineKind {
 impl<'a> Parse<'a> for ModulePart {
     fn parse(parser: Parser<'a>) -> Result<Self, Error> {
         use ValType::*;
-        // Prioritize fields of format "(...)" over single "(" token
-
-        if parser.peek::<InlineExport>()? {
-            Ok(parser.parse::<InlineExport<'a>>()?.into())
-        } else if parser.peek2::<kw::export>()? {
-            parser.parens(|p| Ok(p.parse::<Export<'a>>()?.into()))
+        if parser.peek2::<kw::export>()? {
+            if parser.peek::<InlineExport>()? {
+                parse_func_parts(&parser, false)
+            } else {
+                parser.parens(|p| p.parse::<Export>())?;
+                Ok(ModulePart::Export)
+            }
         } else if parser.peek::<InlineImport>()? {
-            Ok(parser.parse::<InlineImport<'a>>()?.into())
+            Err(parser.error("imports must be on one line"))
         } else if parser.peek2::<kw::import>()? {
-            parser.parens(|p| {
-                let imports = p.parse::<Imports<'a>>()?;
-                match imports {
-                    Imports {
-                        items:
-                            wast::core::ImportItems::Single {
-                                module,
-                                name,
-                                sig: wast::core::ItemSig { ref kind, .. },
-                            },
-                        ..
-                    } => match kind {
-                        ItemKind::Func(_) => Ok(imports.into()),
-                        ItemKind::Global(ty) => {
-                            match check_import(module, name, &HelperImportKind::Global(*ty)) {
-                                None => Ok(imports.into()),
-                                Some(error_message) => Err(parser.error(error_message)),
-                            }
+            parser.parens(|p| match p.parse::<Imports>()? {
+                Imports {
+                    items:
+                        wast::core::ImportItems::Single {
+                            module,
+                            name,
+                            sig: wast::core::ItemSig { kind, .. },
+                        },
+                    ..
+                } => match kind {
+                    ItemKind::Func(ty) => {
+                        check_func_import(&parser, module, name, ty, ImportKind::Import)
+                    }
+                    ItemKind::Global(ty) => {
+                        match check_import(module, name, Some(&HelperImportKind::Global(ty))) {
+                            None => Ok(ModulePart::Import(ImportKind::Import)),
+                            Some(error_message) => Err(parser.error(error_message)),
                         }
-                        ItemKind::Memory(ty) => {
-                            match check_import(module, name, &HelperImportKind::Memory(*ty)) {
-                                None => Ok(imports.into()),
-                                Some(error_message) => Err(parser.error(error_message)),
-                            }
+                    }
+                    ItemKind::Memory(ty) => {
+                        match check_import(module, name, Some(&HelperImportKind::Memory(ty))) {
+                            None => Ok(ModulePart::Import(ImportKind::Import)),
+                            Some(error_message) => Err(parser.error(error_message)),
                         }
-                        _ => Err(parser.error("unsupported import kind")),
-                    },
-
+                    }
                     _ => Err(parser.error("unsupported import kind")),
-                }
-            })
-        } else if parser.peek2::<kw::param>()? {
-            // Modified from FunctionType parser
-            parser.parens(|p| {
-                p.parse::<kw::param>()?;
-                if p.is_empty() {
-                    return Ok(ModulePart::Param);
-                }
+                },
 
-                let id = p.parse::<Option<Id<'a>>>()?;
-                let parse_more = id.is_none();
-                p.parse::<ValType<'a>>()?;
-                while parse_more && !p.is_empty() {
-                    p.parse::<ValType<'a>>()?;
-                }
-
-                Ok(ModulePart::Param)
+                _ => Err(parser.error("unsupported import kind")),
             })
-        } else if parser.peek2::<kw::result>()? {
-            // Modified from FunctionType parser
-            parser.parens(|p| {
-                p.parse::<kw::result>()?;
-                while !p.is_empty() {
-                    p.parse::<ValType<'a>>()?;
-                }
-
-                Ok(ModulePart::Result)
-            })
-        } else if parser.peek2::<kw::local>()? {
-            // Modified from Local parse_remainder
-            parser.parens(|_| Ok(parser.parse::<LocalParser<'a>>()?.into()))
         } else if parser.peek2::<kw::memory>()? {
-            parser.parens(|p| match p.parse::<Memory<'a>>()? {
+            parser.parens(|p| match p.parse::<Memory>()? {
                 Memory {
                     kind:
                         wast::core::MemoryKind::Import {
@@ -279,8 +202,8 @@ impl<'a> Parse<'a> for ModulePart {
                             ..
                         },
                     ..
-                } => match check_import(module, field, &HelperImportKind::Memory(ty)) {
-                    None => Ok(ModulePart::Import),
+                } => match check_import(module, field, Some(&HelperImportKind::Memory(ty))) {
+                    None => Ok(ModulePart::Import(ImportKind::InlineMemory)),
                     Some(error_message) => Err(parser.error(error_message)),
                 },
                 Memory {
@@ -295,7 +218,7 @@ impl<'a> Parse<'a> for ModulePart {
                 _ => Err(parser.error("unsupported memory feature")),
             })
         } else if parser.peek2::<kw::table>()? {
-            parser.parens(|p| match p.parse::<Table<'a>>()? {
+            parser.parens(|p| match p.parse::<Table>()? {
                 Table {
                     kind: wast::core::TableKind::Import { .. },
                     ..
@@ -303,13 +226,13 @@ impl<'a> Parse<'a> for ModulePart {
                 _ => Ok(ModulePart::Table),
             })
         } else if parser.peek2::<kw::global>()? {
-            parser.parens(|p| match p.parse::<Global<'a>>()? {
+            parser.parens(|p| match p.parse::<Global>()? {
                 Global {
                     kind: wast::core::GlobalKind::Import(InlineImport { module, field }),
                     ty,
                     ..
-                } => match check_import(module, field, &HelperImportKind::Global(ty)) {
-                    None => Ok(ModulePart::Import),
+                } => match check_import(module, field, Some(&HelperImportKind::Global(ty))) {
+                    None => Ok(ModulePart::Import(ImportKind::InlineGlobal)),
                     Some(error_message) => Err(parser.error(error_message)),
                 },
                 Global {
@@ -336,37 +259,72 @@ impl<'a> Parse<'a> for ModulePart {
                 },
                 _ => Err(parser.error("unsupported global type")),
             })
-        } else if parser.step(|cursor| match cursor.lparen()? {
-            Some(rest) => Ok((true, rest)),
-            None => Ok((false, cursor)),
-        })? {
-            Ok(ModulePart::LParen)
-        } else if parser.step(|cursor| match cursor.rparen()? {
-            Some(rest) => Ok((true, rest)),
-            None => Ok((false, cursor)),
-        })? {
-            Ok(ModulePart::RParen)
-        } else if parser.peek::<kw::func>()? {
-            Ok(parser.parse::<kw::func>()?.into())
-        } else if parser.peek::<Id<'a>>()? {
-            Ok(parser.parse::<Id<'a>>()?.into())
+        } else if parser.step(|cursor| Ok((cursor.peek_lparen()?, cursor)))?
+            && parser.peek2::<kw::func>()?
+        {
+            parse_func_parts(&parser, true)
         } else {
-            Err(parser.error("expected a non-instruction token"))
+            parse_func_parts(&parser, false)
         }
     }
 }
 
+fn check_func_import(
+    parser: &Parser,
+    module: &str,
+    field: &str,
+    ty: TypeUse<FunctionType>,
+    kind: ImportKind,
+) -> Result<ModulePart, Error> {
+    if ty.index.is_some() {
+        Err(parser.error("type index not supported"))
+    } else {
+        let ty = ty.inline.unwrap_or_default();
+        match check_import(
+            module,
+            field,
+            Some(&HelperImportKind::Func {
+                params: &ty.params.iter().map(|(_, _, p)| *p).collect::<Vec<_>>(),
+                results: &ty.results,
+            }),
+        ) {
+            None => Ok(ModulePart::Import(kind)),
+            Some(error_message) => Err(parser.error(error_message)),
+        }
+    }
+}
+
+fn parse_func_parts(parser: &Parser, import_ok: bool) -> Result<ModulePart, Error> {
+    let mut parts = Vec::new();
+    let checkpoint = parser.step(|cursor| Ok((cursor, cursor)))?;
+
+    loop {
+        if parser.peek::<InlineImport>()? && import_ok {
+            parser.step(|_| Ok(((), checkpoint)))?;
+            return match parser.parens(|p| p.parse::<Func>()) {
+                Ok(Func {
+                    kind: FuncKind::Import(InlineImport { module, field }, _),
+                    ty,
+                    ..
+                }) => check_func_import(parser, module, field, ty, ImportKind::InlineFunc),
+                Err(e) => Err(e),
+                _ => Err(parser.error("unsupported function")),
+            };
+        }
+        parts.push(parser.parse()?);
+        if parser.is_empty() && !parser.step(|c| Ok((c.peek_rparen()?, c)))? {
+            break;
+        }
+    }
+    Ok(ModulePart::Func(parts))
+}
+
 impl Peek for ModulePart {
     fn peek(cursor: Cursor) -> Result<bool, Error> {
-        if cursor.peek_lparen()?
+        Ok(cursor.peek_lparen()?
             || cursor.peek_rparen()?
             || kw::func::peek(cursor)?
-            || Id::peek(cursor)?
-        {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+            || Id::peek(cursor)?)
     }
 
     fn display() -> &'static str {
@@ -377,14 +335,12 @@ impl Peek for ModulePart {
 impl<'a> Parse<'a> for LineKind {
     fn parse(parser: Parser<'a>) -> Result<Self, Error> {
         // In the Codillon editor, a line can contain a single instruction
-        // or a (possibly empty) sequence of ModuleParts.
+        // or a ModulePart: either a single "module-scope" element
+        // (import, export, memory, table, global) or a sequence of parts of
+        // an inline (non-imported) function.
 
         if parser.peek::<ModulePart>()? {
-            let mut parts = Vec::new();
-            while (!parser.is_empty()) || parser.peek::<ModulePart>()? {
-                parts.push(parser.parse()?);
-            }
-            Ok(LineKind::Other(parts))
+            Ok(LineKind::Other(parser.parse()?))
         } else if parser.is_empty() {
             Ok(LineKind::Empty)
         } else {
@@ -397,10 +353,95 @@ impl<'a> Parse<'a> for LineKind {
     }
 }
 
+#[derive(Default)]
+pub struct CodillonParam<'a>(pub FunctionType<'a>);
+
+impl<'a> Parse<'a> for CodillonParam<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self, Error> {
+        // Modified from FunctionType parser
+        let mut params = Vec::new();
+        parser.parens(|p| {
+            p.parse::<kw::param>()?;
+            if p.is_empty() {
+                return Ok(Self::default());
+            }
+            let (id, name) = (p.parse::<Option<_>>()?, p.parse::<Option<_>>()?);
+            let parse_more = id.is_none() && name.is_none();
+            let ty = p.parse()?;
+            params.push((id, name, ty));
+            while parse_more && !p.is_empty() {
+                params.push((None, None, p.parse()?));
+            }
+            Ok(Self(FunctionType {
+                params: params.into(),
+                ..Default::default()
+            }))
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct CodillonResult<'a>(pub FunctionType<'a>);
+
+impl<'a> Parse<'a> for CodillonResult<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self, Error> {
+        // Modified from FunctionType parser
+        let mut results = Vec::new();
+        parser.parens(|p| {
+            p.parse::<kw::result>()?;
+            while !p.is_empty() {
+                results.push(p.parse()?);
+            }
+
+            Ok(Self(FunctionType {
+                results: results.into(),
+                ..Default::default()
+            }))
+        })
+    }
+}
+
+impl<'a> Parse<'a> for FuncPart {
+    fn parse(parser: Parser<'a>) -> Result<Self, Error> {
+        if parser.peek::<kw::func>()? {
+            parser.parse::<kw::func>()?;
+            Ok(FuncPart::FuncKeyword)
+        } else if parser.peek::<Id>()? {
+            parser.parse::<Id>()?;
+            Ok(FuncPart::Id)
+        } else if parser.peek::<InlineExport>()? {
+            parser.parse::<InlineExport>()?;
+            Ok(FuncPart::InlineExport)
+        } else if parser.peek2::<kw::param>()? {
+            parser.parse::<CodillonParam>()?;
+            Ok(FuncPart::Param)
+        } else if parser.peek2::<kw::result>()? {
+            parser.parse::<CodillonResult>()?;
+            Ok(FuncPart::Result)
+        } else if parser.peek2::<kw::local>()? {
+            parser.parens(|p| Ok(FuncPart::Local(p.parse::<LocalParser>()?.locals.len())))
+        } else if parser.peek::<InlineImport>()? {
+            Err(parser.error("imports must be on one line"))
+        } else if parser.step(|cursor| match cursor.lparen()? {
+            Some(rest) => Ok((true, rest)),
+            None => Ok((false, cursor)),
+        })? {
+            Ok(FuncPart::LParen)
+        } else if parser.step(|cursor| match cursor.rparen()? {
+            Some(rest) => Ok((true, rest)),
+            None => Ok((false, cursor)),
+        })? {
+            Ok(FuncPart::RParen)
+        } else {
+            Err(parser.error("unexpected token"))
+        }
+    }
+}
+
 #[derive(Default, Debug, Clone)]
 pub struct SyntheticWasm {
     pub end_opcodes: usize,
-    pub module_field_syntax: Vec<ModulePart>,
+    pub module_field_syntax: Vec<FuncPart>,
     pub module_syntax_first: bool,
 }
 
@@ -449,7 +490,7 @@ impl SyntheticWasm {
 #[derive(Copy, Clone, PartialEq, Debug)]
 enum SyntaxState {
     Initial,
-    AfterModuleFieldLParen,
+    AfterLParen,
     AfterFuncHeader(FuncHeader),
     AfterInstruction,
 }
@@ -458,24 +499,21 @@ enum SyntaxState {
 struct FuncHeader {
     /// Fields in a function header follows an order and some extra restrictions.
     /// This structure tracks and transits states, where each state indicates new fields allowed.
-    // Whether the function has (import ...) field
-    is_import: bool,
     // Lowest possible index for next field in the expected order
     next_field: usize,
 }
 
 impl FuncHeader {
-    fn transit_state(&mut self, part: ModulePart) -> Result<(), &'static str> {
+    fn transit_state(&mut self, part: FuncPart) -> Result<(), &'static str> {
         // Find position (index) of part in the order list
         let part_pos = match part {
             // Expected order of function fields
-            ModulePart::FuncKeyword => 0,  // required
-            ModulePart::Id => 1,           // optional
-            ModulePart::InlineExport => 2, // optional, repeatable
-            ModulePart::InlineImport => 3, // optional
-            ModulePart::Param => 4,        // optional, repeatable
-            ModulePart::Result => 5,       // optional, repeatable,
-            ModulePart::Local(_) => 6,     // optional, repeatable, on individual lines
+            FuncPart::FuncKeyword => 0,  // required
+            FuncPart::Id => 1,           // optional
+            FuncPart::InlineExport => 2, // optional, repeatable
+            FuncPart::Param => 3,        // optional, repeatable
+            FuncPart::Result => 4,       // optional, repeatable,
+            FuncPart::Local(_) => 5,     // optional, repeatable, on individual lines
             _ => return Err("not a function header field"),
         };
 
@@ -487,7 +525,7 @@ impl FuncHeader {
 
         let repeatable = matches!(
             part,
-            ModulePart::Export | ModulePart::Param | ModulePart::Result | ModulePart::Local(_)
+            FuncPart::InlineExport | FuncPart::Param | FuncPart::Result | FuncPart::Local(_)
         );
         let order_invalid = if repeatable {
             part_pos + 1 < self.next_field
@@ -498,14 +536,7 @@ impl FuncHeader {
             return Err("invalid field order");
         }
 
-        // Check for function with (import ...)
-        // function import can't have locals & instructions
-        if self.is_import && matches!(part, ModulePart::Local(_)) {
-            return Err("imported function cannot have locals");
-        }
-
         // Transition state
-        self.is_import |= matches!(part, ModulePart::InlineImport);
         self.next_field = part_pos + 1;
 
         Ok(())
@@ -520,7 +551,7 @@ impl SyntaxState {
     ) -> Result<(), &'static str> {
         if info.synthetic_before.module_syntax_first {
             for part in &info.synthetic_before.module_field_syntax {
-                self.transit_state_from_module_part(*part)?;
+                self.transit_state_from_func_part(*part)?;
                 callback(self);
             }
             if info.synthetic_before.end_opcodes > 0 {
@@ -533,7 +564,7 @@ impl SyntaxState {
                 callback(self);
             }
             for part in &info.synthetic_before.module_field_syntax {
-                self.transit_state_from_module_part(*part)?;
+                self.transit_state_from_func_part(*part)?;
                 callback(self);
             }
         }
@@ -542,58 +573,38 @@ impl SyntaxState {
             return Ok(());
         }
 
-        let mut hit_initial = false;
-        let mut has_local = false;
         let mut has_result = false;
-        let mut has_import = false;
         match &info.kind {
             LineKind::Empty | LineKind::Malformed(_) => {}
             LineKind::Instr(_) => {
                 self.transit_state_from_instruction()?;
                 callback(self);
             }
-            LineKind::Other(parts) => {
-                for part in parts {
-                    // Codiillon only wants one module-scope field per line. If this line reached the initial
-                    // state and then had more syntax afterward, disable it, revert state, and skip to next.
-                    // This rules out lines like "(memory 0) (func)" or "(func) (func)".
-                    if hit_initial {
-                        return Err("fields must be on separate lines");
-                    }
+            LineKind::Other(module_part) => {
+                match module_part {
+                    ModulePart::Func(parts) => {
+                        for part in parts {
+                            // Codillon wants local declarations on their own line.
+                            if matches!(part, FuncPart::Local(_)) && parts.len() > 1 {
+                                return Err("fields must be on separate lines");
+                            }
 
-                    // Codillon also only wants one local declaration per line.
-                    if has_local {
-                        return Err("fields must be on separate lines");
-                    }
-                    if matches!(part, ModulePart::Local(_)) {
-                        has_local = true;
-                        if parts.len() > 1 {
-                            return Err("fields must be on separate lines");
+                            if matches!(part, FuncPart::Result) {
+                                has_result = true;
+                            }
+
+                            self.transit_state_from_func_part(*part)?;
+                            callback(self);
+
+                            if *self == SyntaxState::Initial && has_result {
+                                return Err("function with results must end on another line");
+                            }
                         }
                     }
-                    if matches!(part, ModulePart::Result) {
-                        has_result = true;
-                    }
-
-                    self.transit_state_from_module_part(*part)?;
-                    callback(self);
-
-                    if matches!(
-                        *self,
-                        SyntaxState::AfterFuncHeader(FuncHeader {
-                            is_import: true,
-                            ..
-                        })
-                    ) {
-                        has_import = true;
-                    }
-
-                    if *self == SyntaxState::Initial {
-                        hit_initial = true;
-                        if has_result && !has_import {
-                            return Err("function with results must end on another line");
+                    _ => {
+                        if *self != SyntaxState::Initial {
+                            return Err("invalid field order");
                         }
-                        has_import = false;
                     }
                 }
             }
@@ -612,39 +623,26 @@ impl SyntaxState {
         Ok(())
     }
 
-    fn transit_state_from_module_part(&mut self, part: ModulePart) -> Result<(), &'static str> {
+    fn transit_state_from_func_part(&mut self, part: FuncPart) -> Result<(), &'static str> {
         *self = match (&self, part) {
-            (SyntaxState::Initial, ModulePart::LParen) => SyntaxState::AfterModuleFieldLParen,
-            (
-                SyntaxState::Initial,
-                ModulePart::Memory
-                | ModulePart::Table
-                | ModulePart::Global
-                | ModulePart::Import
-                | ModulePart::Export,
-            ) => SyntaxState::Initial,
-            (SyntaxState::AfterModuleFieldLParen, ModulePart::FuncKeyword) => {
-                SyntaxState::AfterFuncHeader(FuncHeader {
-                    is_import: false,
-                    next_field: 1,
-                })
+            (SyntaxState::Initial, FuncPart::LParen) => SyntaxState::AfterLParen,
+            (SyntaxState::AfterLParen, FuncPart::FuncKeyword) => {
+                SyntaxState::AfterFuncHeader(FuncHeader { next_field: 1 })
             }
             (
                 &&mut SyntaxState::AfterFuncHeader(mut fh),
-                ModulePart::Id
-                | ModulePart::InlineExport
-                | ModulePart::InlineImport
-                | ModulePart::Param
-                | ModulePart::Result
-                | ModulePart::Local(_),
+                FuncPart::Id
+                | FuncPart::InlineExport
+                | FuncPart::Param
+                | FuncPart::Result
+                | FuncPart::Local(_),
             ) => {
                 fh.transit_state(part)?;
                 SyntaxState::AfterFuncHeader(fh)
             }
-            (
-                SyntaxState::AfterFuncHeader(_) | SyntaxState::AfterInstruction,
-                ModulePart::RParen,
-            ) => SyntaxState::Initial,
+            (SyntaxState::AfterFuncHeader(_) | SyntaxState::AfterInstruction, FuncPart::RParen) => {
+                SyntaxState::Initial
+            }
             _ => return Err("invalid field order"),
         };
         Ok(())
@@ -661,7 +659,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
     let mut state = Initial;
     let mut frame_stack: Vec<(InstrKind, DefinedLabel)> = Vec::new();
-    let mut before_imports = true;
+    let mut imports_allowed = true;
 
     // Structures for symbolic references
     let mut module_symbol_defs = ModuleIdentifiers::default();
@@ -673,7 +671,6 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
     // and declare module-scope symbolic ids for any surviving lines.
 
     // There are probably still cases that can produce a "bounce."
-    let mut saw_func = false;
     for line_no in 0..lines.len() {
         lines.set_synthetic_before(line_no, SyntheticWasm::default());
         lines.set_active_status(line_no, Active);
@@ -684,69 +681,44 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
         // If line will be rejected in second pass, don't let it define a symbol.
         let orig_state = state;
-
-        if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
-            match state {
+        match line_kind {
+            LineKind::Instr(_) => match state {
                 // Fix #2 (simulation from below): prepend "(func" if an instruction appears at module scope
                 Initial => {
-                    let _ = state.transit_state_from_module_part(ModulePart::LParen);
-                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
+                    let _ = state.transit_state_from_func_part(FuncPart::LParen);
+                    let _ = state.transit_state_from_func_part(FuncPart::FuncKeyword);
                 }
                 // Fix #3 (simulation from below): prepend "func" if an instruction appears after just "("
-                AfterModuleFieldLParen => {
-                    let _ = state.transit_state_from_module_part(ModulePart::FuncKeyword);
+                AfterLParen => {
+                    let _ = state.transit_state_from_func_part(FuncPart::FuncKeyword);
                 }
                 _ => {}
-            }
+            },
+
+            // Enforce no imports after other module fields
+            LineKind::Other(module_part) => match module_part {
+                ModulePart::Import(_) if imports_allowed => {}
+                ModulePart::Import(_) if !imports_allowed => {
+                    lines.set_active_status(
+                        line_no,
+                        Inactive("imports must appear before other module fields"),
+                    );
+                    continue;
+                }
+                _ => imports_allowed = false,
+            },
+            LineKind::Empty | LineKind::Malformed(_) => (),
         }
 
-        if state
-            .transit_state(lines.info(line_no), |st| match st {
-                SyntaxState::AfterFuncHeader(FuncHeader {
-                    is_import: true, ..
-                }) => saw_func = false,
-                SyntaxState::AfterFuncHeader(_) => saw_func = true,
-                _ => {}
-            })
-            .is_err()
-        {
+        if state.transit_state(lines.info(line_no), |_| {}).is_err() {
             state = orig_state;
             continue;
         }
 
-        if saw_func && state == SyntaxState::Initial {
-            before_imports = false;
-        }
-
-        // Enforce no imports after other module fields
-        if let LineKind::Other(parts) = &line_kind {
-            let has_import = parts
-                .iter()
-                .any(|&p| matches!(p, ModulePart::Import | ModulePart::InlineImport));
-            let module_field = parts.iter().any(|&p| {
-                matches!(
-                    p,
-                    ModulePart::Memory
-                        | ModulePart::Table
-                        | ModulePart::Global
-                        | ModulePart::Export
-                )
-            });
-            if has_import && !before_imports {
-                lines.set_active_status(
-                    line_no,
-                    Inactive("imports must appear before other module fields"),
-                );
-                continue;
-            } else if module_field {
-                before_imports = false;
-            }
-        }
-
         // Collect module-level symbols
-        let collect_result =
-            collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs);
-        if let Err(reason) = collect_result {
+        if let Err(reason) =
+            collect_module_symbols(&lines.info(line_no).symbols, &mut module_symbol_defs)
+        {
             lines.set_active_status(line_no, Inactive(reason));
             continue;
         }
@@ -785,29 +757,20 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
         // Fixup instructions that appear where they don't belong
         if matches!(lines.info(line_no).kind, LineKind::Instr(_)) {
             match state {
-                // Fix #1: Disable an instruction that appears in an imported function, skipping to next line
-                AfterFuncHeader(FuncHeader {
-                    is_import: true, ..
-                }) => {
-                    lines.set_active_status(
-                        line_no,
-                        Inactive("imported functions cannot have instructions"),
-                    );
-                    continue;
-                }
+                // Fix #1: (no longer needed)
                 // Fix #2: prepend "(func" if an instruction appears at module scope
                 Initial => lines.set_synthetic_before(
                     line_no,
                     SyntheticWasm {
-                        module_field_syntax: vec![ModulePart::LParen, ModulePart::FuncKeyword],
+                        module_field_syntax: vec![FuncPart::LParen, FuncPart::FuncKeyword],
                         ..Default::default()
                     },
                 ),
                 // Fix #3: prepend "func" if an instruction appears after just "("
-                AfterModuleFieldLParen => lines.set_synthetic_before(
+                AfterLParen => lines.set_synthetic_before(
                     line_no,
                     SyntheticWasm {
-                        module_field_syntax: vec![ModulePart::FuncKeyword],
+                        module_field_syntax: vec![FuncPart::FuncKeyword],
                         ..Default::default()
                     },
                 ),
@@ -898,7 +861,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
 
     match state {
         // Fix #7: if ending with "(" state, close with "func)"
-        AfterModuleFieldLParen => {
+        AfterLParen => {
             assert!(frame_stack.is_empty());
 
             // Make sure there is an empty line that can become a synthetic "func)"
@@ -913,7 +876,7 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                 SyntheticWasm {
                     module_syntax_first: false,
                     end_opcodes: 0,
-                    module_field_syntax: vec![ModulePart::FuncKeyword, ModulePart::RParen],
+                    module_field_syntax: vec![FuncPart::FuncKeyword, FuncPart::RParen],
                 },
             );
         }
@@ -930,27 +893,12 @@ pub fn fix_syntax(lines: &mut impl LineInfosMut) {
                 SyntheticWasm {
                     module_syntax_first: false,
                     end_opcodes: frame_stack.len(),
-                    module_field_syntax: vec![ModulePart::RParen],
+                    module_field_syntax: vec![FuncPart::RParen],
                 },
             );
         }
         _ => {}
     }
-}
-
-pub fn find_import_lines(code: &impl LineInfos) -> Vec<usize> {
-    let mut imports = Vec::new();
-    for line_no in 0..code.len() {
-        if let LineKind::Other(parts) = &code.info(line_no).kind
-            && code.info(line_no).is_active()
-            && parts
-                .iter()
-                .any(|&p| matches!(p, ModulePart::Import | ModulePart::InlineImport))
-        {
-            imports.push(line_no);
-        }
-    }
-    imports
 }
 
 pub fn find_function_ranges(code: &impl LineInfos) -> Vec<(usize, usize)> {
@@ -967,10 +915,7 @@ pub fn find_function_ranges(code: &impl LineInfos) -> Vec<(usize, usize)> {
 
                 (
                     Some(start_line),
-                    AfterInstruction
-                    | AfterFuncHeader(FuncHeader {
-                        is_import: false, ..
-                    }),
+                    AfterInstruction | AfterFuncHeader(FuncHeader { .. }),
                     Initial,
                 ) => {
                     ranges.push((start_line, line_no));
@@ -1070,31 +1015,32 @@ mod tests {
     fn test_parse_modulepart() -> Result<()> {
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    (   ")?)?,
-            ModulePart::LParen
+            ModulePart::Func(vec![FuncPart::LParen])
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    )    ")?)?,
-            ModulePart::RParen
+            ModulePart::Func(vec![FuncPart::RParen])
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    func    ")?)?,
-            ModulePart::FuncKeyword
+            ModulePart::Func(vec![FuncPart::FuncKeyword])
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    $x    ")?)?,
-            ModulePart::Id
+            ModulePart::Func(vec![FuncPart::Id])
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("  ( export \"main\")    ")?)?,
-            ModulePart::InlineExport
+            ModulePart::Func(vec![FuncPart::InlineExport])
+        );
+        assert!(
+            parse::<ModulePart>(&ParseBuffer::new("  ( import \"foo\" \"bar\" )    ")?).is_err(),
         );
         assert_eq!(
-            parse::<ModulePart>(&ParseBuffer::new("  ( import \"foo\" \"bar\" )    ")?)?,
-            ModulePart::InlineImport
-        );
-        assert_eq!(
-            parse::<ModulePart>(&ParseBuffer::new(r#" ( import "foo" "bar" (func $bar)) "#)?)?,
-            ModulePart::Import
+            parse::<ModulePart>(&ParseBuffer::new(
+                r#" ( import "draw" "clear" (func $bar)) "#
+            )?)?,
+            ModulePart::Import(ImportKind::Import)
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new(r#"  ( export "foo" (func $bar))    "#)?)?,
@@ -1102,18 +1048,21 @@ mod tests {
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    (param $x i32)    ")?)?,
-            ModulePart::Param
+            ModulePart::Func(vec![FuncPart::Param])
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    ( result i32 f32 i64   )    ")?)?,
-            ModulePart::Result
+            ModulePart::Func(vec![FuncPart::Result])
         );
         assert_eq!(
             parse::<ModulePart>(&ParseBuffer::new("    (local $x    f64 )    ")?)?,
-            ModulePart::Local(1)
+            ModulePart::Func(vec![FuncPart::Local(1)])
         );
         assert!(parse::<ModulePart>(&ParseBuffer::new("( param")?).is_err());
-        assert!(parse::<ModulePart>(&ParseBuffer::new("()")?).is_err());
+        assert_eq!(
+            parse::<ModulePart>(&ParseBuffer::new("()")?)?,
+            ModulePart::Func(vec![FuncPart::LParen, FuncPart::RParen])
+        );
         Ok(())
     }
 
@@ -1143,65 +1092,71 @@ mod tests {
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new("   (   ")?)?,
-            LineKind::Other(vec![ModulePart::LParen])
+            LineKind::Other(ModulePart::Func(vec![FuncPart::LParen]))
         );
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new(")")?)?,
-            LineKind::Other(vec![ModulePart::RParen])
+            LineKind::Other(ModulePart::Func(vec![FuncPart::RParen]))
         );
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new("()")?)?,
-            LineKind::Other(vec![ModulePart::LParen, ModulePart::RParen])
+            LineKind::Other(ModulePart::Func(vec![FuncPart::LParen, FuncPart::RParen]))
         );
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new(")func")?)?,
-            LineKind::Other(vec![ModulePart::RParen, ModulePart::FuncKeyword])
+            LineKind::Other(ModulePart::Func(vec![
+                FuncPart::RParen,
+                FuncPart::FuncKeyword
+            ]))
         );
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new(") func")?)?,
-            LineKind::Other(vec![ModulePart::RParen, ModulePart::FuncKeyword])
+            LineKind::Other(ModulePart::Func(vec![
+                FuncPart::RParen,
+                FuncPart::FuncKeyword
+            ]))
         );
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new("   (func)   ")?)?,
-            LineKind::Other(vec![
-                ModulePart::LParen,
-                ModulePart::FuncKeyword,
-                ModulePart::RParen
-            ])
+            LineKind::Other(ModulePart::Func(vec![
+                FuncPart::LParen,
+                FuncPart::FuncKeyword,
+                FuncPart::RParen
+            ]))
         );
 
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new(
-                " ( func $foo ( export \"main\") (import \"modu\" \"bar\") (param $x i32) (result i32 f64) (local $tmp i64)"
+                " ( func $foo ( export \"main\") (param $x i32) (result i32 f64) (local $tmp i64)"
             )?)?,
-            LineKind::Other(vec![
-                ModulePart::LParen,
-                ModulePart::FuncKeyword,
-                ModulePart::Id,
-                ModulePart::InlineExport,
-                ModulePart::InlineImport,
-                ModulePart::Param,
-                ModulePart::Result,
-                ModulePart::Local(1)
-            ])
+            LineKind::Other(ModulePart::Func(vec![
+                FuncPart::LParen,
+                FuncPart::FuncKeyword,
+                FuncPart::Id,
+                FuncPart::InlineExport,
+                FuncPart::Param,
+                FuncPart::Result,
+                FuncPart::Local(1)
+            ]))
         );
+
         assert_eq!(
             parse::<LineKind>(&ParseBuffer::new(
-                "(import \"foo\" \"bar\" (func $bar)) (func $baz) (export \"foo\" (func $baz))"
+                " ( func $foo ( export \"main\") (import \"draw\" \"point\") (param $x f64) (param $y f64))"
             )?)?,
-            LineKind::Other(vec![
-                ModulePart::Import,
-                ModulePart::LParen,
-                ModulePart::FuncKeyword,
-                ModulePart::Id,
-                ModulePart::RParen,
-                ModulePart::Export
-            ])
+            LineKind::Other(ModulePart::Import(ImportKind::InlineFunc))
+        );
+
+        assert!(
+            parse::<LineKind>(&ParseBuffer::new(
+                "(import \"draw\" \"clear\" (func $bar)) (func $baz) (export \"foo\" (func $baz))"
+            )?)
+            .is_err()
         );
 
         assert!(parse::<LineKind>(&ParseBuffer::new(") func i32.const 7")?).is_err());
@@ -1213,45 +1168,42 @@ mod tests {
     fn test_func_header() -> Result<()> {
         // valid state transitions
         let mut header_valid = FuncHeader::default();
-        let _ = header_valid.transit_state(ModulePart::FuncKeyword);
-        assert!(!header_valid.is_import);
+        let _ = header_valid.transit_state(FuncPart::FuncKeyword);
         assert_eq!(header_valid.next_field, 1);
-        let _ = header_valid.transit_state(ModulePart::InlineExport);
-        assert!(!header_valid.is_import);
+        let _ = header_valid.transit_state(FuncPart::InlineExport);
         assert_eq!(header_valid.next_field, 3);
-        let _ = header_valid.transit_state(ModulePart::InlineExport);
-        assert!(!header_valid.is_import);
+        let _ = header_valid.transit_state(FuncPart::InlineExport);
         assert_eq!(header_valid.next_field, 3);
-        let _ = header_valid.transit_state(ModulePart::InlineImport);
-        assert!(header_valid.is_import);
-        assert_eq!(header_valid.next_field, 4);
-        let _ = header_valid.transit_state(ModulePart::Result);
-        assert!(header_valid.is_import);
+        let _ = header_valid.transit_state(FuncPart::Result);
+        assert_eq!(header_valid.next_field, 5);
+        let _ = header_valid.transit_state(FuncPart::Local(1));
+        assert_eq!(header_valid.next_field, 6);
+        let _ = header_valid.transit_state(FuncPart::Local(3));
         assert_eq!(header_valid.next_field, 6);
 
-        // local after import
-        assert!(header_valid.transit_state(ModulePart::Local(1)).is_err());
+        // param after local
+        assert!(header_valid.transit_state(FuncPart::Param).is_err());
 
         // no func keyword
         let mut header_no_func_keyword = FuncHeader::default();
         assert!(
             header_no_func_keyword
-                .transit_state(ModulePart::Param)
+                .transit_state(FuncPart::Param)
                 .is_err()
         );
 
         // invalid order
         let mut header_invalid_order = FuncHeader::default();
-        let _ = header_invalid_order.transit_state(ModulePart::FuncKeyword);
-        let _ = header_invalid_order.transit_state(ModulePart::Result);
-        assert!(header_invalid_order.transit_state(ModulePart::Id).is_err());
+        let _ = header_invalid_order.transit_state(FuncPart::FuncKeyword);
+        let _ = header_invalid_order.transit_state(FuncPart::Result);
+        assert!(header_invalid_order.transit_state(FuncPart::Id).is_err());
 
         // repeat non-repeatable field
         let mut header_non_repeatable = FuncHeader::default();
-        let _ = header_non_repeatable.transit_state(ModulePart::FuncKeyword);
+        let _ = header_non_repeatable.transit_state(FuncPart::FuncKeyword);
         assert!(
             header_non_repeatable
-                .transit_state(ModulePart::FuncKeyword)
+                .transit_state(FuncPart::FuncKeyword)
                 .is_err()
         );
 
@@ -1275,13 +1227,10 @@ mod tests {
             parse_line("i32.const 4 i32.const 5"),
             malf("extra tokens remaining after parse")
         );
-        assert_eq!(
-            parse_line("(i32.const 4)"),
-            malf("expected a non-instruction token")
-        );
+        assert_eq!(parse_line("(i32.const 4)"), malf("unexpected token"));
         assert_eq!(
             parse_line("(i32.add (i32.const 4) (i32.const 5))"),
-            malf("expected a non-instruction token")
+            malf("unexpected token")
         );
         //spaces before and after, comments, and empty lines are well-formed
         assert_eq!(
@@ -1392,35 +1341,32 @@ mod tests {
 
         {
             // Test case 6: Imports after other module fields
-            let mut infos6 =
-                TestLineInfos::new(["(global i32 (i32.const 0))", "(import \"\" \"\" (func))"]);
+            // (N.B. needs to be an acceptable mod/field or else marked malformed and still "active")
+            let mut infos6 = TestLineInfos::new([
+                "(global i32 (i32.const 0))",
+                "(import \"draw\" \"clear\" (func))",
+            ]);
             fix_syntax(&mut infos6);
             assert!(infos6.lines[0].is_active());
             assert!(!infos6.lines[1].is_active());
 
-            infos6 =
-                TestLineInfos::new(["(global i32 (i32.const 0))", "(func (import \"\" \"\"))"]);
+            infos6 = TestLineInfos::new([
+                "(global i32 (i32.const 0))",
+                "(func (import \"draw\" \"clear\"))",
+            ]);
             fix_syntax(&mut infos6);
             assert!(infos6.lines[0].is_active());
             assert!(!infos6.lines[1].is_active());
 
-            infos6 = TestLineInfos::new(["(func)", "(import \"\" \"\" (func))"]);
+            infos6 = TestLineInfos::new(["(func)", "(import \"draw\" \"clear\" (func))"]);
             fix_syntax(&mut infos6);
             assert!(infos6.lines[0].is_active());
             assert!(!infos6.lines[1].is_active());
 
-            infos6 = TestLineInfos::new(["(func)", "(func (import \"\" \"\"))"]);
+            infos6 = TestLineInfos::new(["(func)", "(func (import \"draw\" \"clear\"))"]);
             fix_syntax(&mut infos6);
             assert!(infos6.lines[0].is_active());
             assert!(!infos6.lines[1].is_active());
-        }
-
-        {
-            // Import with params and results on one line
-            let mut infos =
-                TestLineInfos::new(["(func $x (import \"x\" \"y\") (param i32) (result f64))"]);
-            fix_syntax(&mut infos);
-            assert!(infos.lines[0].is_well_formed());
         }
 
         {
@@ -1431,10 +1377,59 @@ mod tests {
         }
 
         {
-            // Multi-line imported function, then a non-import module field
+            // Imported function, then a non-import module field
             let mut infos = TestLineInfos::new([
-                "(func $x (import \"x\" \"y\") (param i32)",
-                "(result f64))",
+                "(func $x (import \"draw\" \"set_color\") (param i32 i32 i32))",
+                "(memory 1)",
+            ]);
+            fix_syntax(&mut infos);
+            assert!(infos.lines[0].is_well_formed());
+            assert!(infos.lines[1].is_well_formed());
+        }
+
+        {
+            // Attempted multi-line imported function (import on first line)
+            let mut infos = TestLineInfos::new([
+                "(func $x (import \"draw\" \"set_color\")",
+                "(param i32 i32 i32))",
+                "(memory 1)",
+            ]);
+            fix_syntax(&mut infos);
+            assert!(!infos.lines[0].is_well_formed());
+            assert!(infos.lines[0].is_active());
+            assert!(!infos.lines[1].is_well_formed());
+            assert!(!infos.lines[1].is_active());
+            assert!(infos.lines[2].is_well_formed());
+            assert_eq!(
+                infos.lines[0].kind,
+                LineKind::Malformed("expected `)`".to_string())
+            );
+            assert_eq!(
+                infos.lines[1].active,
+                Activity::Inactive("invalid field order")
+            );
+        }
+
+        {
+            // Attempted multi-line imported function (import on second line)
+            let mut infos = TestLineInfos::new([
+                "(func $x",
+                "(import \"draw\" \"set_color\") (param i32 i32 i32))",
+                "(memory 1)",
+            ]);
+            fix_syntax(&mut infos);
+            assert!(infos.lines[0].is_well_formed());
+            assert_eq!(
+                infos.lines[1].kind,
+                LineKind::Malformed("imports must be on one line".to_string())
+            );
+        }
+
+        {
+            // Multi-line exported function
+            let mut infos = TestLineInfos::new([
+                "(func $x",
+                "(export \"hello\") (param i32 i32 i32))",
                 "(memory 1)",
             ]);
             fix_syntax(&mut infos);
@@ -1444,16 +1439,35 @@ mod tests {
         }
 
         {
-            // Multi-line imported function, then another import
+            // Multi-line exported+imported function (inline import after inline export)
             let mut infos = TestLineInfos::new([
-                "(func $x (import \"x\" \"y\") (param i32)",
-                "(result f64))",
+                "(func $x",
+                "(export \"hello\") (import \"draw\" \"set_color\") (param i32 i32 i32))",
+                "(memory 1)",
+            ]);
+            fix_syntax(&mut infos);
+            assert!(infos.lines[0].is_well_formed());
+            assert!(!infos.lines[1].is_well_formed());
+            assert!(!infos.lines[2].is_well_formed());
+            assert_eq!(
+                infos.lines[1].kind,
+                LineKind::Malformed("imports must be on one line".to_string())
+            );
+            assert_eq!(
+                infos.lines[2].active,
+                Activity::Inactive("invalid field order")
+            );
+        }
+
+        {
+            // Imported function, then another import
+            let mut infos = TestLineInfos::new([
+                "(func $x (import \"draw\" \"set_color\") (param i32 i32 i32))",
                 "(memory (import \"listen\" \"listen_memory\") 1)",
             ]);
             fix_syntax(&mut infos);
             assert!(infos.lines[0].is_well_formed());
             assert!(infos.lines[1].is_well_formed());
-            assert!(infos.lines[2].is_well_formed());
         }
 
         {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{
-    FrameInfo, FrameInfosMut, InstrKind, LineInfos, LineInfosMut, LineKind, ModulePart,
-    find_function_ranges, find_import_lines,
+    FrameInfo, FrameInfosMut, FuncPart, InstrKind, LineInfos, LineInfosMut, LineKind, ModulePart,
+    find_function_ranges,
 };
 use EncoderInstruction::*;
 use anyhow::{Result, bail};
@@ -79,8 +79,8 @@ impl InstrImports {
 #[derive(PartialEq, Eq)]
 pub enum HelperImportKind<'a> {
     Func {
-        params: &'a [ValType],
-        results: &'a [ValType],
+        params: &'a [TextValType<'a>],
+        results: &'a [TextValType<'a>],
     },
     Global(TextGlobalType<'a>),
     Memory(TextMemoryType),
@@ -99,7 +99,7 @@ const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
             HelperImport {
                 name: "point",
                 kind: HelperImportKind::Func {
-                    params: &[ValType::F64, ValType::F64],
+                    params: &[TextValType::F64, TextValType::F64],
                     results: &[],
                 },
                 reason: "expected type (param f64 f64)",
@@ -115,7 +115,7 @@ const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
             HelperImport {
                 name: "set_color",
                 kind: HelperImportKind::Func {
-                    params: &[ValType::I32, ValType::I32, ValType::I32],
+                    params: &[TextValType::I32, TextValType::I32, TextValType::I32],
                     results: &[],
                 },
                 reason: "expected type (param i32 i32 i32)",
@@ -123,7 +123,12 @@ const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
             HelperImport {
                 name: "set_extent",
                 kind: HelperImportKind::Func {
-                    params: &[ValType::F64, ValType::F64, ValType::F64, ValType::F64],
+                    params: &[
+                        TextValType::F64,
+                        TextValType::F64,
+                        TextValType::F64,
+                        TextValType::F64,
+                    ],
                     results: &[],
                 },
                 reason: "expected type (param f64 f64 f64 f64)",
@@ -131,7 +136,7 @@ const HELPER_IMPORTS: &[(&str, &[HelperImport])] = &[
             HelperImport {
                 name: "set_radius",
                 kind: HelperImportKind::Func {
-                    params: &[ValType::F64],
+                    params: &[TextValType::F64],
                     results: &[],
                 },
                 reason: "expected type (param f64)",
@@ -329,10 +334,8 @@ impl<'a> RawModule<'a> {
             let mut globals_iter = globals.iter_mut();
             for line_no in 0..editor.len() {
                 if editor.info(line_no).is_active()
-                    && let LineKind::Other(parts) = &editor.info(line_no).kind
-                    && parts.first() == Some(&ModulePart::Global)
+                    && let LineKind::Other(ModulePart::Global) = &editor.info(line_no).kind
                 {
-                    debug_assert_eq!(parts.len(), 1);
                     let glob = globals_iter.next().expect("not enough globals in module");
                     glob.line_idx = line_no;
                     glob.position_id = editor.info(line_no).id;
@@ -366,8 +369,8 @@ impl<'a> RawModule<'a> {
             let mut locals_iter = locals.iter_mut();
             for line_no in start_line..=end_line {
                 if editor.info(line_no).is_active()
-                    && let LineKind::Other(parts) = &editor.info(line_no).kind
-                    && let Some(ModulePart::Local(num)) = parts.first()
+                    && let LineKind::Other(ModulePart::Func(parts)) = &editor.info(line_no).kind
+                    && let Some(FuncPart::Local(num)) = parts.first()
                 {
                     debug_assert_eq!(parts.len(), 1);
                     for _ in 0..*num {
@@ -430,46 +433,11 @@ impl<'a> RawModule<'a> {
     ) -> Result<ValidModule<'a>> {
         let parser = wasmparser::Parser::new(0);
         let mut validator = Validator::new_with_features(CODILLON_WASM_FEATURES);
-        let import_lines = find_import_lines(editor);
         let mut allocs = wasmparser::FuncValidatorAllocations::default();
-
-        /* Disable unlinkable function imports (other imports were already syntactically disabled) */
-        let mut imports = Vec::new();
-
-        for (import_idx, import @ wasmparser::Import { module, name, ty }) in
-            self.imports.into_iter().enumerate()
-        {
-            let wasmparser::TypeRef::Func(type_idx) = ty else {
-                imports.push(import);
-                continue;
-            };
-
-            let func_type = &self.types[type_idx as usize];
-
-            match check_import(
-                module,
-                name,
-                &HelperImportKind::Func {
-                    params: func_type.params(),
-                    results: func_type.results(),
-                },
-            ) {
-                None => imports.push(import),
-                Some(reason) => {
-                    editor.set_invalid(import_lines[import_idx], Some(reason));
-
-                    imports.push(wasmparser::Import {
-                        module: "codillon_debug",
-                        name: "func_placeholder",
-                        ty: wasmparser::TypeRef::Func(type_idx),
-                    });
-                }
-            }
-        }
 
         let mut ret = ValidModule {
             types: self.types,
-            imports,
+            imports: self.imports,
             memory: self.memory,
             globals: self.globals,
             functions: Vec::with_capacity(self.functions.len()),
@@ -770,7 +738,7 @@ impl<'a> RawModule<'a> {
 pub fn check_import(
     import_module: &str,
     import_name: &str,
-    import_kind: &HelperImportKind,
+    import_kind: Option<&HelperImportKind>,
 ) -> Option<String> {
     // Check if module name exists
     for (module, components) in HELPER_IMPORTS {
@@ -778,8 +746,8 @@ pub fn check_import(
             for HelperImport { name, kind, reason } in *components {
                 // Check if component name exists
                 if *name == import_name {
-                    // Check if function type matches
-                    return if import_kind == kind {
+                    // Check if type matches
+                    return if import_kind == Some(kind) {
                         None
                     } else {
                         Some(reason.to_string())
@@ -2932,10 +2900,6 @@ pub(crate) mod tests {
         linker.func_wrap("codillon_debug", "record_invalid", |ctx: Ctx<'_>| {
             ctx.data().set_termination_type(TerminationType::HitInvalid)
         })?;
-        linker.func_wrap("codillon_debug", "func_placeholder", |ctx: Ctx<'_>| {
-            ctx.data()
-                .set_termination_type(TerminationType::HitBadImport)
-        })?;
         linker.func_wrap("codillon_debug", "record_i32", |ctx: Ctx<'_>, v: i32, s| {
             ctx.data().record_slot(v, s)
         })?;
@@ -3262,7 +3226,7 @@ pub(crate) mod tests {
             assert_eq!(TerminationType::HitInvalid, log.termination_type());
         }
 
-        // syntax error (func has inline import but also instructions -- will deactivate the instructions)
+        // (func has inline import -- will deactivate the import)
         {
             let mut editor = FakeTextBuffer::default();
             editor.push_line("(func");
@@ -3274,11 +3238,36 @@ pub(crate) mod tests {
             editor.push_line("(func)");
             let expected = String::from("(module\n")
                 + EXPECTED_TYPES
+                + "  (type (func (param i32 i32) (result i32)))\n"
                 + EXPECTED_IMPORTS
-                + r#"  (import "codillon_debug" "func_placeholder" (func (type 0)))
-  (export "main" (func 12))
-  (func (type 0)
+                + EXPECTED_MAIN
+                + r#"  (func (type 0)
     i32.const 0
+    call 6
+    i32.const 0
+    call 13
+    i32.const 2
+    call 13
+    i32.const 7
+    i32.const 0
+    call 14
+    i32.const 3
+    call 13
+    i32.const 8
+    i32.const 1
+    call 14
+    i32.const 4
+    call 13
+    i32.const 9
+    i32.const 2
+    call 14
+    i32.const 5
+    call 13
+    call 1
+    unreachable
+  )
+  (func (type 0)
+    i32.const 1
     call 6
     i32.const 6
     call 13
@@ -3286,11 +3275,18 @@ pub(crate) mod tests {
     call 13
   )
 "# + EXPECTED_STEP
-                + ")\n";
+                + r#"  (func (type 8) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    call 2
+    local.get 0
+  )
+)
+"#;
             let EditorOutput { text, binary, .. } = test_editor_flow(&mut editor)?;
             let log = test_execution(&binary, &[], &mut [])?;
             assert_eq!(expected, text);
-            assert_eq!(TerminationType::Success, log.termination_type());
+            assert_eq!(TerminationType::HitInvalid, log.termination_type());
         }
 
         // syntax error (consumed symbolic reference not defined - module-level, local, label)
@@ -3737,42 +3733,6 @@ pub(crate) mod tests {
             assert_eq!(TerminationType::HitInvalid, log.termination_type());
         }
 
-        // placeholder import is called
-        {
-            let mut editor = FakeTextBuffer::default();
-            editor.push_line("(import \"x\" \"y\" (func $f))");
-            editor.push_line("(func");
-            editor.push_line("call $f");
-            editor.push_line(")");
-            let expected = String::from("(module\n")
-                + EXPECTED_TYPES
-                + EXPECTED_IMPORTS
-                + r#"  (import "codillon_debug" "func_placeholder" (func (type 0)))
-  (export "main" (func 12))
-  (func (type 0)
-    i32.const 0
-    call 6
-    i32.const 1
-    call 13
-    i32.const 2
-    call 13
-    call 7
-    call 11
-    i32.const 0
-    call 8
-    i32.const -2147483646
-    call 13
-    i32.const 3
-    call 13
-  )
-"# + EXPECTED_STEP
-                + ")\n";
-            let EditorOutput { text, binary, .. } = test_editor_flow(&mut editor)?;
-            let log = test_execution(&binary, &[], &mut [])?;
-            assert_eq!(expected, text);
-            assert_eq!(TerminationType::HitBadImport, log.termination_type());
-        }
-
         {
             // issue #168
             let mut editor = FakeTextBuffer::default();
@@ -4024,12 +3984,8 @@ pub(crate) mod tests {
             editor.push_line("(import \"not_draw\" \"point\" (func (param f64 f64)))");
             test_editor_flow(&mut editor)?;
             assert_eq!(
-                editor.lines[0]
-                    .info
-                    .invalid
-                    .as_ref()
-                    .expect("nonexistent module name should be invalid"),
-                "module ‘not_draw’ not found"
+                editor.lines[0].info.kind,
+                LineKind::Malformed("module ‘not_draw’ not found".to_string())
             );
         }
 
@@ -4039,12 +3995,8 @@ pub(crate) mod tests {
             editor.push_line("(import \"draw\" \"not_point\" (func (param f64 f64)))");
             test_editor_flow(&mut editor)?;
             assert_eq!(
-                editor.lines[0]
-                    .info
-                    .invalid
-                    .as_ref()
-                    .expect("nonexistent component name should be invalid"),
-                "field ‘not_point’ not found in module draw"
+                editor.lines[0].info.kind,
+                LineKind::Malformed("field ‘not_point’ not found in module draw".to_string())
             );
         }
 
@@ -4054,12 +4006,8 @@ pub(crate) mod tests {
             editor.push_line("(import \"draw\" \"point\" (func (param i32)))");
             test_editor_flow(&mut editor)?;
             assert_eq!(
-                editor.lines[0]
-                    .info
-                    .invalid
-                    .as_ref()
-                    .expect("wrong function type should be invalid"),
-                "expected type (param f64 f64)"
+                editor.lines[0].info.kind,
+                LineKind::Malformed("expected type (param f64 f64)".to_string())
             );
         }
 
@@ -4095,60 +4043,39 @@ pub(crate) mod tests {
             editor.push_line(")");
             test_editor_flow(&mut editor)?;
             assert_eq!(
-                editor.lines[0]
-                    .info
-                    .invalid
-                    .as_ref()
-                    .expect("a/b should be invalid"),
-                "module ‘a’ not found"
+                editor.lines[0].info.kind,
+                LineKind::Malformed("module ‘a’ not found".to_string())
             );
             assert!(
                 editor.lines[1].info.invalid.is_none(),
                 "clear_canvas should be valid"
             );
             assert_eq!(
-                editor.lines[2]
-                    .info
-                    .invalid
-                    .as_ref()
-                    .expect("c/d should be invalid"),
-                "module ‘c’ not found"
+                editor.lines[2].info.kind,
+                LineKind::Malformed("module ‘c’ not found".to_string())
             );
             assert!(
                 editor.lines[3].info.invalid.is_none(),
                 "draw_point should be valid"
             );
             assert_eq!(
-                editor.lines[4]
-                    .info
-                    .invalid
-                    .as_ref()
-                    .expect("e/f should be invalid"),
-                "module ‘e’ not found"
+                editor.lines[4].info.kind,
+                LineKind::Malformed("module ‘e’ not found".to_string())
             );
-            /*
-             * Skip below, because we aren't statically tracking calls to invalid imports at the callsite.
-             * (This would be hard to do for call_indirect, etc.)
-             * TODO: signal the HitBadImport at execution time on the culprit line.
-
-                for i in 5..editor.len() {
-                    if i % 2 == 0 {
-                        assert_eq!(
-                            editor.lines[i]
-                                .info
-                                .invalid
-                                .as_ref()
-                                .expect("invalid import test should be invalid"),
-                            "call to invalid import"
-                        );
-                    } else {
-                        assert!(
-                            editor.lines[i].info.invalid.is_none(),
-                            "invalid import test line {i} should be invalid"
-                        );
-                    }
+            for i in 6..editor.lines.len() {
+                if i % 2 == 0 {
+                    assert_eq!(
+                        editor.lines[i].info.active,
+                        Activity::Inactive("undefined symbolic reference"),
+                    );
+                } else {
+                    assert!(
+                        editor.lines[i].info.is_well_formed()
+                            && editor.lines[i].info.invalid.is_none(),
+                        "import test line {i} should be valid"
+                    );
+                }
             }
-            */
         }
 
         // Test case 6: valid global and memory imports


### PR DESCRIPTION
- All imports (including inline func imports) need to be on one line
- Disable all bad imports syntactically
- Eliminate func_placeholder and HitBadImport termination type
- Parse + extract symbol usage a little more regularly