### PR TITLE
Propagate "identity" to connections (in this case by "src"/written coordinate)

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -495,12 +495,9 @@ impl ExecutionState {
             CallFrameOp::EnterBlock(block_idx) => {
                 let (lower, upper) = connections.blocks[*block_idx as usize];
                 for slot_idx in lower.usize()..upper.usize() {
-                    let cur_but_old = self.slots[slot_idx]
-                        .last()
-                        .copied()
-                        .flatten()
-                        .map(|SlotContents { val, .. }| SlotContents { val, old: true });
-                    *self.slots[slot_idx].last_mut().unwrap() = cur_but_old;
+                    self.slots[slot_idx]
+                        .last_mut()
+                        .map(|x| x.as_mut().map(|y| y.old = true));
                 }
             }
         }

--- a/src/dom_set.rs
+++ b/src/dom_set.rs
@@ -1,4 +1,4 @@
-// A Codillon DOM "set": an unordered collection of Components of the same type, indexed by a u32
+// A Codillon DOM "set": an unordered collection of Components of the same type, indexed by an arbitrary key
 
 use crate::{
     dom_vec::DomVec,
@@ -6,16 +6,17 @@ use crate::{
 };
 use std::{
     collections::{HashMap, VecDeque},
+    hash::Hash,
     ops::{Index, IndexMut},
 };
 
-pub struct DomSet<Child: Component, Element: AnyElement> {
+pub struct DomSet<Child: Component, Element: AnyElement, Key> {
     contents: DomVec<Child, Element>,
-    mapping: HashMap<u32, usize>,
+    mapping: HashMap<Key, usize>,
     free_list: VecDeque<usize>,
 }
 
-impl<Child: Component, Element: AnyElement> DomSet<Child, Element> {
+impl<Child: Component, Element: AnyElement, Key: Eq + Hash> DomSet<Child, Element, Key> {
     pub fn new(elem: ElementHandle<Element>) -> Self {
         Self {
             contents: DomVec::new(elem),
@@ -24,8 +25,10 @@ impl<Child: Component, Element: AnyElement> DomSet<Child, Element> {
         }
     }
 
-    pub fn insert(&mut self, id: u32, val: Child) {
-        if let Some(idx) = self.free_list.pop_front() {
+    pub fn insert(&mut self, id: Key, val: Child) {
+        if let Some(idx) = self.mapping.get(&id) {
+            self.contents[*idx].assign(val);
+        } else if let Some(idx) = self.free_list.pop_front() {
             self.mapping.insert(id, idx);
             self.contents[idx].assign(val);
         } else {
@@ -34,10 +37,16 @@ impl<Child: Component, Element: AnyElement> DomSet<Child, Element> {
         }
     }
 
-    pub fn remove(&mut self, id: u32, default: Child) {
+    pub fn remove(&mut self, id: Key, default: Child) {
         let idx = self.mapping.remove(&id).unwrap();
         self.contents[idx].assign(default);
         self.free_list.push_back(idx);
+    }
+
+    pub fn rehome(&mut self, cur_id: &Key, new_id: Key) {
+        assert!(!self.mapping.contains_key(&new_id));
+        let idx = self.mapping.remove(cur_id).unwrap();
+        self.mapping.insert(new_id, idx);
     }
 
     pub fn len(&self) -> usize {
@@ -48,51 +57,59 @@ impl<Child: Component, Element: AnyElement> DomSet<Child, Element> {
         self.mapping.is_empty()
     }
 
-    pub fn get(&self, id: u32) -> Option<&Child> {
-        self.mapping
-            .get(&id)
-            .and_then(|idx| self.contents.get(*idx))
+    pub fn get(&self, id: &Key) -> Option<&Child> {
+        self.mapping.get(id).and_then(|idx| self.contents.get(*idx))
     }
 
-    pub fn get_mut(&mut self, id: u32) -> Option<&mut Child> {
+    pub fn get_mut(&mut self, id: Key) -> Option<&mut Child> {
         self.mapping
             .get(&id)
             .and_then(|idx| self.contents.get_mut(*idx))
     }
 
-    pub fn ids(&self) -> impl Iterator<Item = &u32> {
+    pub fn ids(&self) -> impl Iterator<Item = &Key> {
         self.mapping.keys()
     }
 
-    pub fn for_each_mut(&mut self, mut f: impl FnMut(u32, &mut Child)) {
+    pub fn for_each(&mut self, mut f: impl FnMut(&Key, &Child)) {
         for (id, idx) in self.mapping.iter() {
-            f(*id, &mut self.contents[*idx])
+            f(id, &self.contents[*idx])
+        }
+    }
+
+    pub fn for_each_mut(&mut self, mut f: impl FnMut(&Key, &mut Child)) {
+        for (id, idx) in self.mapping.iter() {
+            f(id, &mut self.contents[*idx])
         }
     }
 }
 
-impl<Child: Component, Element: AnyElement> Index<u32> for DomSet<Child, Element> {
+impl<Child: Component, Element: AnyElement, Key: Eq + Hash> Index<Key>
+    for DomSet<Child, Element, Key>
+{
     type Output = Child;
 
-    fn index(&self, id: u32) -> &Child {
+    fn index(&self, id: Key) -> &Child {
         &self.contents[self.mapping[&id]]
     }
 }
 
-impl<Child: Component, Element: AnyElement> IndexMut<u32> for DomSet<Child, Element> {
-    fn index_mut(&mut self, id: u32) -> &mut Child {
+impl<Child: Component, Element: AnyElement, Key: Eq + Hash> IndexMut<Key>
+    for DomSet<Child, Element, Key>
+{
+    fn index_mut(&mut self, id: Key) -> &mut Child {
         &mut self.contents[self.mapping[&id]]
     }
 }
 
-impl<Child: Component, Element: AnyElement> Component for DomSet<Child, Element> {
+impl<Child: Component, Element: AnyElement, Key> Component for DomSet<Child, Element, Key> {
     #[cfg(debug_assertions)]
     fn audit(&self) {
         self.contents.audit();
     }
 }
 
-impl<Child: Component, Element: AnyElement> WithElement for DomSet<Child, Element> {
+impl<Child: Component, Element: AnyElement, Key> WithElement for DomSet<Child, Element, Key> {
     type Element = Element;
     fn with_element<T, F: FnMut(&Element) -> T>(&self, f: F, g: AccessToken) -> T {
         self.contents.with_element(f, g)

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -21,8 +21,9 @@ use crate::{
         fix_syntax,
     },
     utils::{
-        AnnotatedOperatorType, FmtError, OperatorType, RawModule, SlotConnections, SlotInfo,
-        TypedModule, ValidModule, find_connections, indent_and_frame, str_to_binary,
+        AnnotatedOperatorType, ConnectionSource, FmtError, OperatorType, RawModule,
+        SlotConnections, SlotInfo, TypedModule, ValidModule, find_connections, indent_and_frame,
+        str_to_binary,
     },
 };
 use anyhow::{Context, Result, bail};
@@ -170,14 +171,9 @@ impl FrameInfosMut for Editor {
         }
     }
 
-    fn set_frames(&mut self, frames: Vec<FrameInfo>) {
-        let mut tagged_frames = HashMap::with_capacity(frames.len());
-        for frame in frames {
-            let id = self.line(frame.start).id();
-            tagged_frames.insert(id, frame);
-        }
-        let animated = self.component.get_attribute("class") == Some("animated");
-        self.image_mut().set_frames(tagged_frames, animated);
+    fn set_frames(&mut self, frames: HashMap<u32, FrameInfo>) {
+        let smooth = self.component.get_attribute("class") == Some("animated");
+        self.image_mut().set_frames(frames, smooth);
     }
 }
 
@@ -308,13 +304,13 @@ impl Editor {
 
         for (slot_idx, value) in self.execution_state.slots.iter().enumerate() {
             let value = value.last().unwrap_or(&None);
-            let where_written = &self.slot_connections.connections[slot_idx].written;
-            if let Some(coord) = where_written {
+            if let ConnectionSource::Written(coord) =
+                &self.slot_connections.connections[slot_idx].written
+            {
                 get_mut!(self.component, image).set_slot_value(coord, false, value);
             }
 
-            let where_read = &self.slot_connections.connections[slot_idx].read;
-            if let Some(coord) = where_read {
+            if let Some(coord) = &self.slot_connections.connections[slot_idx].read {
                 get_mut!(self.component, image).set_slot_value(coord, true, value);
             }
         }
@@ -852,7 +848,7 @@ impl Editor {
         // set types of globals
         for (global, global_type) in zip_eq(&validized.globals, &types.globals) {
             tagged_types.insert(
-                self.line(global.line_idx).id(),
+                global.position_id,
                 FractionInfo {
                     line_no: global.line_idx,
                     indent: 0,
@@ -879,7 +875,7 @@ impl Editor {
                     })
                     .collect();
                 tagged_types.insert(
-                    self.line(func.lines.0).id(),
+                    func.positions.0,
                     FractionInfo {
                         line_no: func.lines.0,
                         indent: 0,
@@ -907,7 +903,7 @@ impl Editor {
                             // flush
                             let indent = self.line(line_idx).info().indent.unwrap_or(0);
                             tagged_types.insert(
-                                self.line(line_idx).id(),
+                                local.position_id,
                                 FractionInfo {
                                     line_no: line_idx,
                                     indent,
@@ -961,9 +957,10 @@ impl Editor {
                     .iter()
                     .map(|x| SlotInfo {
                         slot: types.slots[x.usize()].clone(),
-                        used: self.slot_connections.connections[x.usize()]
-                            .written
-                            .is_some(),
+                        used: matches!(
+                            self.slot_connections.connections[x.usize()].written,
+                            ConnectionSource::Written(_)
+                        ),
                     })
                     .collect();
                 let mut all_used = true;
@@ -993,7 +990,7 @@ impl Editor {
                     }
                 } else {
                     tagged_types.insert(
-                        self.line(op.line_idx).id(),
+                        op.position_id,
                         FractionInfo {
                             line_no: op.line_idx,
                             indent,
@@ -1005,7 +1002,7 @@ impl Editor {
         }
 
         self.image_mut().set_types(tagged_types, true);
-        get_mut!(self.component, image).set_connections(&self.slot_connections);
+        get_mut!(self.component, image).set_connections(&self.slot_connections.connections);
         Ok(())
     }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -11,15 +11,15 @@ use crate::{
     jet::{AccessToken, Component, ElementFactory, ElementHandle, WithElement, now_ms},
     line::INDENT_PX,
     syntax::{FrameInfo, InstrKind},
-    utils::{
-        AnnotatedOperatorType, BLOCK_BOUNDARY_INDENT, Coordinate, SlotConnection, SlotConnections,
-        SlotInfo,
-    },
+    utils::{AnnotatedOperatorType, BLOCK_BOUNDARY_INDENT, Coordinate, SlotConnection, SlotInfo},
 };
 use anyhow::Result;
 use delegate::delegate;
 use palette::{Mix, Srgb};
-use std::{collections::HashMap, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 use thousands::Separable;
 use wasmparser::ValType;
 use web_sys::{
@@ -566,9 +566,9 @@ type SVGDefs = DomStruct<
     ),
     SvgDefsElement,
 >;
-type CodillonBlocks = DomSet<FrameLine, SvggElement>; // the lines themselves
-type Fractions = DomSet<OperatorFraction, SvggElement>;
-type Connections = DomVec<ElementHandle<SvgPathElement>, SvggElement>;
+type CodillonBlocks = DomSet<FrameLine, SvggElement, u32>; // the lines themselves
+type Fractions = DomSet<OperatorFraction, SvggElement, u32>;
+type Connections = DomSet<ElementHandle<SvgPathElement>, SvggElement, Coordinate>;
 type CodillonSVG = DomStruct<
     (
         SVGDefs,
@@ -583,6 +583,7 @@ pub struct DomImage {
     width: u16,
     factory: ElementFactory,
     pending_delete: HashMap<u32, f64>, // frame identity -> timestamp to delete
+    connection_dsts: HashMap<Coordinate /* dst */, Coordinate /* src */>,
 }
 
 impl WithElement for DomImage {
@@ -665,6 +666,10 @@ macro_rules! field {
 impl DomImage {
     fn defs_mut(&mut self) -> &mut SVGDefs {
         get_mut!(self.contents, defs)
+    }
+
+    fn connections(&mut self) -> &Connections {
+        get!(self.contents, connections)
     }
 
     fn connections_mut(&mut self) -> &mut Connections {
@@ -756,6 +761,7 @@ impl DomImage {
             width: 0,
             factory: factory.clone(),
             pending_delete: Default::default(),
+            connection_dsts: Default::default(),
         };
 
         ret.arrow_mut()
@@ -1042,7 +1048,7 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
             smooth = true;
         }
         for (id, info) in &frames {
-            let Some(old_block) = self.blocks().get(*id) else {
+            let Some(old_block) = self.blocks().get(id) else {
                 smooth = true;
                 break;
             };
@@ -1065,9 +1071,9 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
 
         /* smoothly vanish frames that no longer exist */
         get_mut!(self.contents, blocks).for_each_mut(|id, block| {
-            if !frames.contains_key(&id) {
+            if !frames.contains_key(id) {
                 block.set_visibility(true, false, false);
-                self.pending_delete.insert(id, now + 1000.0);
+                self.pending_delete.insert(*id, now + 1000.0);
             }
         });
 
@@ -1076,7 +1082,7 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
             self.make_height_at_least(info.end + 2);
             self.make_width_at_least(info.indent);
 
-            if self.blocks().get(id).is_none() {
+            if self.blocks().get(&id).is_none() {
                 get_mut!(self.contents, blocks).insert(id, FrameLine::new(&self.factory));
             }
 
@@ -1115,7 +1121,7 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
             self.make_height_at_least(line_no + 2);
             self.make_width_at_least(indent);
 
-            if self.fractions().get(id).is_none() {
+            if self.fractions().get(&id).is_none() {
                 get_mut!(self.contents, fractions)
                     .insert(id, OperatorFraction::new(&self.factory, line_no, indent));
             }
@@ -1132,7 +1138,6 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
 
     fn make_connection(
         &mut self,
-        connection_idx: usize,
         src: &Coordinate,
         dst: &Coordinate,
         is_bad: bool, // adjust trajectory to fit through openings in the "empty" reader symbols
@@ -1164,11 +1169,7 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
             write_y
         };
 
-        while connection_idx >= self.connections_mut().len() {
-            let newpath = self.factory.svg_path();
-            self.connections_mut().push(newpath);
-        }
-        let cx = &mut self.connections_mut()[connection_idx];
+        let mut cx = self.factory.svg_path();
         if is_bad {
             cx.set_attribute("stroke", ty_to_color(&src_ty.as_ref()));
             cx.set_attr_num("stroke-dasharray", "1");
@@ -1186,23 +1187,47 @@ A 15,10 0 0 1 14.827,-8.484 15,10 0 0 1 0.003,-0 15,10 0 0 1 -14.826,-8.481 15,1
 C {write_x},{first_control_height} {second_control_x},{second_control_height}, {read_x},{read_y}"
             ),
         );
+
+        self.connections_mut().insert(src.clone(), cx);
     }
 
-    pub fn set_connections(&mut self, connections: &SlotConnections) {
-        let mut connection_idx = 0;
-        for (src, dst) in &connections.bad_connections {
-            self.make_connection(connection_idx, src, dst, true);
-            connection_idx += 1;
-        }
-        for SlotConnection { written, read } in &connections.connections {
-            let (Some(src), Some(dst)) = (written, read) else {
-                continue;
-            };
+    pub fn set_connections(&mut self, connections: &Vec<SlotConnection>) {
+        /* rehome connections when possible */
+        let cx_sources: HashSet<Coordinate> = connections
+            .iter()
+            .filter_map(|c| c.read.as_ref().and_then(|_| c.written.source().cloned()))
+            .collect();
 
-            self.make_connection(connection_idx, src, dst, false);
-            connection_idx += 1;
+        for new_conn in connections {
+            if let Some(src) = new_conn.written.source()
+                && let Some(dst) = &new_conn.read
+                && self.connections().get(src).is_none()
+                && let Some(cur_src) = self.connection_dsts.get(dst)
+                && !cx_sources.contains(cur_src)
+            {
+                get_mut!(self.contents, connections).rehome(cur_src, src.clone());
+            }
         }
-        self.connections_mut().truncate(connection_idx);
+
+        /* delete connections that no longer exist */
+        {
+            let mut to_vanish: Vec<Coordinate> = vec![];
+            for id in self.connections().ids() {
+                if !cx_sources.contains(id) {
+                    to_vanish.push(id.clone());
+                }
+            }
+            for id in to_vanish {
+                get_mut!(self.contents, connections).remove(id, self.factory.svg_path());
+            }
+        }
+
+        /* add connections from given SlotConnections */
+        for SlotConnection { written, read } in connections {
+            if let (Some(src), Some(dst)) = (written.source(), read) {
+                self.make_connection(src, dst, written.is_mismatch());
+            }
+        }
     }
 
     pub fn set_slot_value(

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -1043,9 +1043,15 @@ pub trait Component: WithNode {
     where
         Self: Sized,
     {
+        #[cfg(debug_assertions)]
+        let was_connected = self.is_connected();
         self.replace_with(&mut other, TOKEN);
         std::mem::swap(self, &mut other);
-        debug_assert!(self.is_connected());
+
+        #[cfg(debug_assertions)]
+        if was_connected {
+            debug_assert!(self.is_connected());
+        }
         debug_assert!(!other.is_connected());
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -9,7 +9,7 @@ use crate::{
     utils::{HelperImportKind, check_import},
 };
 use anyhow::Result;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use wast::{
     Error,
     core::{
@@ -107,7 +107,7 @@ pub struct FrameInfo {
 
 pub trait FrameInfosMut: LineInfos {
     fn set_indent(&mut self, index: usize, num: u16);
-    fn set_frames(&mut self, frames: Vec<FrameInfo>);
+    fn set_frames(&mut self, frames: HashMap<u32, FrameInfo>);
 }
 
 impl LineKind {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1680,15 +1680,36 @@ pub struct TypedModule {
     pub funcs: Vec<TypedFunction>,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct Coordinate {
     pub position_id: u32,
     pub operand_num: usize,
 }
 
 #[derive(Default, Debug, PartialEq, Clone)]
+pub enum ConnectionSource {
+    #[default]
+    None,
+    Written(Coordinate),
+    Mismatch(Coordinate),
+}
+
+impl ConnectionSource {
+    pub fn source(&self) -> Option<&Coordinate> {
+        match self {
+            ConnectionSource::None => None,
+            ConnectionSource::Written(x) | ConnectionSource::Mismatch(x) => Some(x),
+        }
+    }
+
+    pub fn is_mismatch(&self) -> bool {
+        matches!(self, ConnectionSource::Mismatch(_))
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct SlotConnection {
-    pub written: Option<Coordinate>,
+    pub written: ConnectionSource,
     pub read: Option<Coordinate>,
 }
 
@@ -1697,7 +1718,6 @@ pub struct SlotConnections {
     pub connections: Vec<SlotConnection>, // same index space as Slot #
     pub first_slot_of_func: Vec<SlotUse>, // indexed by "local" function idx (not including func imports)
     pub blocks: Vec<(SlotUse, SlotUse)>,
-    pub bad_connections: Vec<(Coordinate, Coordinate)>,
 }
 
 impl SlotConnections {
@@ -1731,19 +1751,18 @@ pub fn find_connections(module: &ValidModule, tys: &TypedModule) -> SlotConnecti
     let mut cx = SlotConnections {
         connections: vec![
             SlotConnection {
-                written: None,
+                written: ConnectionSource::None,
                 read: None
             };
             tys.slots.len()
         ],
         first_slot_of_func: Vec::with_capacity(tys.funcs.len()),
         blocks: tys.blocks.clone(),
-        bad_connections: vec![],
     };
 
     // locate globals
     for (Aligned { position_id, .. }, slot_idx) in zip_eq(&module.globals, &tys.globals) {
-        cx.connections[slot_idx.usize()].written = Some(Coordinate {
+        cx.connections[slot_idx.usize()].written = ConnectionSource::Written(Coordinate {
             position_id: *position_id,
             operand_num: 0,
         });
@@ -1769,7 +1788,7 @@ pub fn find_connections(module: &ValidModule, tys: &TypedModule) -> SlotConnecti
                 local_counter.0 = Some(*position_id);
                 local_counter.1 = 0;
             }
-            cx.connections[slot_idx.usize()].written = Some(Coordinate {
+            cx.connections[slot_idx.usize()].written = ConnectionSource::Written(Coordinate {
                 position_id: *position_id,
                 operand_num: local_counter.1,
             });
@@ -1779,7 +1798,7 @@ pub fn find_connections(module: &ValidModule, tys: &TypedModule) -> SlotConnecti
             zip_eq(&func.operators, &func_tys.ops)
         {
             for (operand_num, idx) in outputs.iter().enumerate() {
-                cx.connections[idx.usize()].written = Some(Coordinate {
+                cx.connections[idx.usize()].written = ConnectionSource::Written(Coordinate {
                     position_id: *position_id,
                     operand_num,
                 });
@@ -1805,18 +1824,13 @@ pub fn find_connections(module: &ValidModule, tys: &TypedModule) -> SlotConnecti
             OperatorType { inputs, outputs },
         ) in zip_eq(&func.operators, &func_tys.ops)
         {
-            for (operand_num, slot) in inputs.iter().enumerate().rev() {
-                if cx.connections[slot.usize()].written.is_none()
+            for slot in inputs.iter().rev() {
+                let conn = cx.connections.get_mut(slot.usize()).unwrap();
+                if conn.written == ConnectionSource::None
                     && stranded.len() > *accessible_heights.last().unwrap()
                     && let Some(where_written) = stranded.pop()
                 {
-                    cx.bad_connections.push((
-                        where_written,
-                        Coordinate {
-                            position_id: *position_id,
-                            operand_num,
-                        },
-                    ));
+                    conn.written = ConnectionSource::Mismatch(where_written);
                 }
             }
 
@@ -1875,21 +1889,30 @@ pub fn indent_and_frame(code: &mut impl FrameInfosMut, module: &ValidModule, typ
         slots: Vec<SlotUse>,
     }
 
-    let mut frames: Vec<FrameInfo> = module
+    let mut frames: HashMap<u32, FrameInfo> = module
         .functions
         .iter()
-        .map(|ValidFunction { lines, .. }| FrameInfo {
-            indent: 0,
-            start: lines.0,
-            end: lines.1,
-            unclosed: false,
-            kind: InstrKind::OtherStructured,
-            wide: !code
-                .info(lines.0)
-                .synthetic_before
-                .module_field_syntax
-                .is_empty(),
-        })
+        .map(
+            |ValidFunction {
+                 lines, positions, ..
+             }| {
+                (
+                    positions.0,
+                    FrameInfo {
+                        indent: 0,
+                        start: lines.0,
+                        end: lines.1,
+                        unclosed: false,
+                        kind: InstrKind::OtherStructured,
+                        wide: !code
+                            .info(lines.0)
+                            .synthetic_before
+                            .module_field_syntax
+                            .is_empty(),
+                    },
+                )
+            },
+        )
         .collect();
     let mut frame_stack: Vec<OpenFrame> = Vec::new();
 
@@ -2023,28 +2046,34 @@ pub fn indent_and_frame(code: &mut impl FrameInfosMut, module: &ValidModule, typ
                             Operator::Block { .. } | Operator::Loop { .. } | Operator::If { .. }
                         ));
                         let f = frame_stack.pop().expect("malformed frame stack");
-                        frames.push(FrameInfo {
-                            indent: f.indent,
-                            start: line_no,
-                            end: f.end,
-                            unclosed: f.synthetic,
-                            kind,
-                            wide: false,
-                        });
+                        frames.insert(
+                            typed_op.0.position_id,
+                            FrameInfo {
+                                indent: f.indent,
+                                start: line_no,
+                                end: f.end,
+                                unclosed: f.synthetic,
+                                kind,
+                                wide: false,
+                            },
+                        );
                         instr_indent = f.indent + BLOCK_BOUNDARY_INDENT;
                         process_outputs(&mut slot_map, &f.slots); // clear open slots
                     }
                     InstrKind::Else => {
                         debug_assert!(typed_op.0.inner.op == Operator::Else);
                         let f = frame_stack.pop().expect("malformed frame stack");
-                        frames.push(FrameInfo {
-                            indent: f.indent,
-                            start: line_no,
-                            end: f.end,
-                            unclosed: f.synthetic,
-                            kind,
-                            wide: false,
-                        });
+                        frames.insert(
+                            typed_op.0.position_id,
+                            FrameInfo {
+                                indent: f.indent,
+                                start: line_no,
+                                end: f.end,
+                                unclosed: f.synthetic,
+                                kind,
+                                wide: false,
+                            },
+                        );
                         process_outputs(&mut slot_map, &f.slots); // clear open slots
                         frame_stack.push(OpenFrame {
                             end: line_no,
@@ -2827,7 +2856,7 @@ pub(crate) mod tests {
 
     impl FrameInfosMut for FakeTextBuffer {
         fn set_indent(&mut self, _index: usize, _num: u16) {}
-        fn set_frames(&mut self, _frames: Vec<FrameInfo>) {}
+        fn set_frames(&mut self, _frames: HashMap<u32, FrameInfo>) {}
     }
 
     struct EditorOutput {
@@ -3904,21 +3933,24 @@ pub(crate) mod tests {
                 connections.connections,
                 vec![
                     SlotConnection {
-                        written: Some(Coordinate {
+                        written: ConnectionSource::Written(Coordinate {
                             position_id: 1,
                             operand_num: 0
                         }),
                         read: None
                     },
                     SlotConnection {
-                        written: None,
+                        written: ConnectionSource::Mismatch(Coordinate {
+                            position_id: 1,
+                            operand_num: 0
+                        }),
                         read: Some(Coordinate {
                             position_id: 2,
                             operand_num: 0
                         })
                     },
                     SlotConnection {
-                        written: Some(Coordinate {
+                        written: ConnectionSource::Written(Coordinate {
                             position_id: 2,
                             operand_num: 0
                         }),
@@ -3927,19 +3959,6 @@ pub(crate) mod tests {
                 ]
             );
             assert_eq!(connections.first_slot_of_func, vec![SlotUse::new(0)]);
-            assert_eq!(
-                connections.bad_connections,
-                vec![(
-                    Coordinate {
-                        position_id: 1,
-                        operand_num: 0
-                    },
-                    Coordinate {
-                        position_id: 2,
-                        operand_num: 0
-                    }
-                )]
-            );
         }
 
         {
@@ -3955,21 +3974,21 @@ pub(crate) mod tests {
                 connections.connections,
                 vec![
                     SlotConnection {
-                        written: Some(Coordinate {
+                        written: ConnectionSource::Written(Coordinate {
                             position_id: 2,
                             operand_num: 0
                         }),
                         read: None
                     },
                     SlotConnection {
-                        written: None,
+                        written: ConnectionSource::None,
                         read: Some(Coordinate {
                             position_id: 4,
                             operand_num: 0
                         })
                     },
                     SlotConnection {
-                        written: Some(Coordinate {
+                        written: ConnectionSource::Written(Coordinate {
                             position_id: 4,
                             operand_num: 0
                         }),
@@ -3978,7 +3997,6 @@ pub(crate) mod tests {
                 ]
             );
             assert_eq!(connections.first_slot_of_func, vec![SlotUse::new(0)]);
-            assert!(connections.bad_connections.is_empty());
         }
 
         {
@@ -3992,17 +4010,33 @@ pub(crate) mod tests {
             editor.push_line(")");
             let EditorOutput { connections, .. } = test_editor_flow(&mut editor)?;
             assert_eq!(
-                connections.bad_connections,
-                vec![(
-                    Coordinate {
-                        position_id: 1,
-                        operand_num: 0
+                connections.connections,
+                vec![
+                    SlotConnection {
+                        written: ConnectionSource::Written(Coordinate {
+                            position_id: 1,
+                            operand_num: 0
+                        }),
+                        read: None
                     },
-                    Coordinate {
-                        position_id: 4,
-                        operand_num: 0
-                    }
-                )]
+                    SlotConnection {
+                        written: ConnectionSource::Mismatch(Coordinate {
+                            position_id: 1,
+                            operand_num: 0
+                        }),
+                        read: Some(Coordinate {
+                            position_id: 4,
+                            operand_num: 0
+                        })
+                    },
+                    SlotConnection {
+                        written: ConnectionSource::Written(Coordinate {
+                            position_id: 4,
+                            operand_num: 0
+                        }),
+                        read: None
+                    },
+                ]
             );
         }
 
@@ -4549,9 +4583,9 @@ pub(crate) mod tests {
             let log = test_execution(&binary, &[], &mut [])?;
             assert_eq!(TerminationType::HitInvalid, log.termination_type());
             assert_eq!(connections.connections.len(), 2);
-            assert!(connections.connections[0].written.is_none());
+            assert_eq!(connections.connections[0].written, ConnectionSource::None);
             assert!(connections.connections[0].read.is_none());
-            assert!(connections.connections[1].written.is_none());
+            assert_eq!(connections.connections[1].written, ConnectionSource::None);
             assert!(connections.connections[1].read.is_none());
         }
 


### PR DESCRIPTION
Propagate "identity" to connections (in this case by "src"/written coordinate)
    
Rehomes connection identity if there should be a connection and:
- there's no existing connection with the same "src"
- there is an existing connection with the same "dst", and
- that connection's "src" no longer originates a connection


Closes: #250